### PR TITLE
Fix outdated package name in AccessRights docs

### DIFF
--- a/docs/AccessRights.md
+++ b/docs/AccessRights.md
@@ -1,5 +1,5 @@
 # Access Rights
-When sails-adminpanel starts, for every Model it creates 4 access rights tokens:
+When Adminizer starts, for every Model it creates 4 access rights tokens:
 - create
 - read
 - update


### PR DESCRIPTION
## Summary
- update AccessRights docs to use **Adminizer** instead of the old package name

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684069120eb48325a7bcaad43dc2a5d7