### PR TITLE
Add split configuration docs

### DIFF
--- a/docs/Configuration/CustomComponents.md
+++ b/docs/Configuration/CustomComponents.md
@@ -1,0 +1,36 @@
+# Custom Components
+
+Adminizer can be extended with custom controls and dashboard widgets.
+
+## Controls
+
+Controls are reusable form inputs. Create a class extending `AbstractControls` and register it via `ControlsHandler`:
+
+```ts
+class ReactQuill extends AbstractControls {
+  readonly name = 'react-quill';
+  readonly type = 'wysiwyg';
+  readonly path = {
+    jsPath: { dev: '/modules/react-quill.tsx', production: '/assets/react-quill.es.js' },
+    cssPath: '/assets/react-quill.css'
+  };
+}
+
+adminizer.emitter.on('adminizer:loaded', () => {
+  adminizer.controlsHandler.add(new ReactQuill(adminizer));
+});
+```
+
+After registration the control can be referenced in field options:
+
+```js
+editor: {
+  title: 'Editor',
+  type: 'wysiwyg',
+  options: { name: 'react-quill' }
+}
+```
+
+## Widgets
+
+Widgets are dashboard blocks. See [Widgets](Widgets.md) for a detailed example of creating and bundling custom widgets.

--- a/docs/Configuration/Fields.md
+++ b/docs/Configuration/Fields.md
@@ -1,0 +1,30 @@
+# Field Options
+
+Fields in a model can be configured in several ways.
+
+### Notation
+
+* **Boolean** – include or exclude the field
+  ```js
+  email: true,
+  password: false,
+  ```
+* **String** – overrides the field title
+  ```js
+  name: "User Name",
+  ```
+* **Object** – full configuration
+  ```js
+  bio: {
+    title: 'Biography',
+    type: 'text',
+    required: true,
+    tooltip: 'Shown on profile',
+  }
+  ```
+
+Field definitions can be placed globally under `models.fields` or inside an action (`list.fields`, `edit.fields`, etc.). Action level settings override the global ones.
+
+### Types
+
+Commonly used field types include `string`, `password`, `date`, `datetime`, `integer`, `boolean`, `text`, `select` and more. When a `text` field has the `editor` option, a WYSIWYG control will be used.

--- a/docs/Configuration/General.md
+++ b/docs/Configuration/General.md
@@ -1,0 +1,28 @@
+# General Configuration
+
+Adminizer is configured through a single `AdminizerConfig` object. The object describes global settings and the models that should appear in the interface.
+
+```ts
+import { AdminizerConfig } from "adminizer";
+
+const config: AdminizerConfig = {
+  routePrefix: "/admin",
+  auth: true,
+  dashboard: true,
+  models: {},
+};
+```
+
+**Key global options**
+
+| Option | Description |
+|--------|-------------|
+| `routePrefix` | Base URL for the panel. Defaults to `/admin`. |
+| `linkAssets` | Symlink static assets instead of copying them. |
+| `identifierField` | Default primary key for models (usually `id`). |
+| `showORMtime` | Show `createdAt`/`updatedAt` fields in forms. |
+| `models` | Object with model definitions. |
+| `dashboard` | Enable dashboard widgets. |
+| `showVersion` | Display Adminizer version in the sidebar. |
+
+Additional options like `welcome`, `translation` and `administrator` credentials can also be provided.

--- a/docs/Configuration/Localization.md
+++ b/docs/Configuration/Localization.md
@@ -1,0 +1,17 @@
+# Localization
+
+Adminizer supports interface translations using the `translation` block in the configuration.
+
+```js
+module.exports.adminpanel = {
+  translation: {
+    locales: ['en', 'de'],
+    path: 'config/locales',
+    defaultLocale: 'en'
+  }
+};
+```
+
+* `locales` – list of available locales
+* `path` – relative path to translation files
+* `defaultLocale` – locale used when none is specified

--- a/docs/Configuration/Models.md
+++ b/docs/Configuration/Models.md
@@ -1,0 +1,31 @@
+# Models
+
+Models describe how each resource is presented in the admin panel. A model entry resides in the `models` section of the config and enables CRUD actions.
+
+```js
+module.exports.adminpanel = {
+  models: {
+    users: {
+      title: 'Users',
+      model: 'User',
+      list: true,
+      add: true,
+      edit: true,
+      view: true,
+      remove: true
+    }
+  }
+};
+```
+
+Available actions are `list`, `add`, `edit`, `view` and `remove`. Each action can be:
+
+* `true`/`false` – enable or disable the action;
+* an object with additional options (for example `limit` or `fields` for `list`).
+
+A model can also define:
+
+* `hide` – exclude it from the sidebar;
+* `icon` – material icon name;
+* `identifierField` – custom primary key;
+* `titleField` – field used in relations or lists.


### PR DESCRIPTION
## Summary
- document admin panel configuration
- explain models, field options and custom components
- describe localization settings

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68410454218c8325a3943ae3aee21db6