### PR TITLE
Add UI component list

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,9 @@
 - Expanded Global UI documentation with external usage examples.
 
 ## 2025-06-19
+- Added `UIComponents.md` with a summary of all global UI components.
+
+## 2025-06-19
 - Exposed all UI components on `window.UIComponents` for use by external modules.
 - Updated module build config to treat each UI component as an external.
 - Documented global UI components usage.

--- a/docs/UIComponents.md
+++ b/docs/UIComponents.md
@@ -1,0 +1,35 @@
+# UI Component List
+
+Below is a brief overview of each React UI component exposed via `window.UIComponents`.
+
+- **Avatar** – user image container with fallback initials.
+- **Badge** – small label for statuses or counts.
+- **Breadcrumb** – hierarchical navigation trail.
+- **Button** – styled button supporting variants and sizes.
+- **Calendar** – date picker using the Radix calendar API.
+- **Card** – container with header, content and footer sections.
+- **Checkbox** – form checkbox element.
+- **Collapsible** – show or hide content with animation.
+- **Command** – command palette container.
+- **ContextMenu** – right-click menu wrapper.
+- **DialogStack** – stackable dialogs for complex flows.
+- **Dialog** – modal dialog with header and footer slots.
+- **DropdownMenu** – triggerable menu for actions or selections.
+- **Input** – styled text input field.
+- **Label** – text label associated with form elements.
+- **Menubar** – horizontal navigation bar with menus.
+- **Pagination** – next/previous and page number navigation.
+- **Popover** – small overlay pop-up container.
+- **Select** – styled select box built on Radix.
+- **Separator** – horizontal or vertical divider line.
+- **Sheet** – slide-over panel for secondary content.
+- **Sidebar** – vertical navigation container.
+- **Skeleton** – placeholder loading indicator.
+- **Slider** – draggable range input.
+- **Sonner** – themed toast notifications.
+- **Switch** – toggle switch control.
+- **Table** – scrollable table wrapper with subcomponents.
+- **Textarea** – multiline text input.
+- **Tooltip** – hover or focus information bubble.
+
+These components live under `src/assets/js/components/ui` and can be imported from the global container for reuse in external modules.

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,3 +29,4 @@
 * [Field-Level Restrictions](AccessControl/FieldRestrictions.md)
 * [Role & Group Management](AccessControl/RoleGroups.md)
 * [Global UI Components](GlobalUI.md)
+* [UI Component List](UIComponents.md)


### PR DESCRIPTION
## Summary
- document available UI components and usage
- link UI component list from the docs index
- log docs addition in HISTORY

## Testing
- `npm run build`
- `npm test` *(fails: cannot find example associations)*
- `npm run dev` *(fails: cannot find module 'reflect-metadata')*

------
https://chatgpt.com/codex/tasks/task_e_68539ab747a08325a22c441fa30f48d2