### PR TITLE
Fix global UI registration

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,9 @@
 - Expanded Global UI documentation with external usage examples.
 
 ## 2025-06-19
+- Fixed startup error when `window.UIComponents` was undefined. `registerUIComponents()` now initializes the global container and documentation updated.
+
+## 2025-06-19
 - Added `UIComponents.md` with a summary of all global UI components.
 
 ## 2025-06-19

--- a/docs/GlobalUI.md
+++ b/docs/GlobalUI.md
@@ -35,3 +35,5 @@ export default function Example() {
 ```
 
 Make sure the Adminizer bundle is loaded before your module so that `registerUIComponents()` has populated `window.UIComponents`.
+
+The `registerUIComponents()` function automatically creates `window.UIComponents` if it doesn't already exist. This avoids runtime errors like `Uncaught TypeError: Cannot convert undefined or null to object` when the container is missing.

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -29,3 +29,17 @@ The configuration system looks up the model config by exact key match. If the ke
 **Planned Improvements:**
 
 In the future, we will introduce the concept of a *model entity*, which will allow for more flexible and case-independent model resolution.
+
+### 🛠️ "Cannot convert undefined or null to object" when starting
+
+**Description:**
+
+If `window.UIComponents` is not initialized before calling `registerUIComponents()`, the application may fail with the following error:
+
+```
+Uncaught TypeError: Cannot convert undefined or null to object
+```
+
+**Solution:**
+
+As of version 4.1.0, `registerUIComponents()` now creates `window.UIComponents` automatically when it is missing. Ensure you are using the latest code and simply call `registerUIComponents()` once during app startup.

--- a/src/assets/js/ui-globals.ts
+++ b/src/assets/js/ui-globals.ts
@@ -208,6 +208,9 @@ import {
 export function registerUIComponents(): void {
 
 //@ts-ignore
+window.UIComponents ??= {};
+
+//@ts-ignore
 Object.assign(window.UIComponents, {
     Avatar,
     AvatarImage,


### PR DESCRIPTION
## Summary
- ensure `registerUIComponents` initializes the global container
- document automatic `UIComponents` creation
- add startup troubleshooting tips
- note fix in HISTORY

## Testing
- `npm run build`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_6853cd48b8ac8325ba7e8e49c4eadc0c