### PR TITLE
Add system theme option with switcher

### DIFF
--- a/docs/Appearance.md
+++ b/docs/Appearance.md
@@ -1,0 +1,7 @@
+# Appearance Settings
+
+Adminizer allows users to switch between **light**, **dark**, and **system** themes. The system option follows the operating system preference.
+
+The theme selector stores the chosen mode in `localStorage` and a cookie so that the preference persists between sessions and across browser tabs.
+
+Use the ThemeSwitcher component in your layout to present the selection buttons. It relies on `useAppearance` to manage the current mode and applies the appropriate classes to the document root.

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -1,0 +1,3 @@
+# Change Log
+
+- Added system theme option and ThemeSwitcher component.

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,7 @@
 
 * [Inertia Adapter & Flash](InertiaAdapter.md)
 * [Form Error Management](FormError.md)
+* [Appearance](Appearance.md)
 
 ## 4. Admin Panel Features
 

--- a/src/assets/js/components/app-sidebar-header.tsx
+++ b/src/assets/js/components/app-sidebar-header.tsx
@@ -2,13 +2,9 @@ import { Breadcrumbs } from '@/components/breadcrumbs';
 import { SidebarTrigger } from '@/components/ui/sidebar';
 import { type BreadcrumbItem as BreadcrumbItemType } from '@/types';
 import {NavUser} from "@/components/nav-user.tsx";
-import { Button } from './ui/button';
-import {Icon} from "@/components/icon";
-import { useAppearance } from '@/hooks/use-appearance';
-import {Moon, Sun} from "lucide-react"
+import ThemeSwitcher from '@/components/theme-switcher';
 
 export function AppSidebarHeader({ breadcrumbs = [] }: { breadcrumbs?: BreadcrumbItemType[] }) {
-    const { appearance, updateAppearance } = useAppearance();
     return (
         <header className="border-sidebar-border/50 flex h-16 shrink-0 items-center gap-2 border-b px-6 transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12 md:px-4">
             <div className="flex justify-between w-full">
@@ -17,17 +13,7 @@ export function AppSidebarHeader({ breadcrumbs = [] }: { breadcrumbs?: Breadcrum
                     <Breadcrumbs breadcrumbs={breadcrumbs}/>
                 </div>
                 <div className="flex gap-4 items-center">
-                    <Button
-                        variant="ghost" size="icon"
-                        className={`shrink-0 cursor-pointer`}
-                        onClick={() => updateAppearance(appearance === 'light' ? 'dark' : 'light')}
-                    >
-                        {appearance === 'light' ? (
-                            <Icon iconNode={Moon} className="h-2 w-2" />
-                        ) : (
-                            <Icon iconNode={Sun} className="h-2 w-2 text-white" />
-                        )}
-                    </Button>
+                    <ThemeSwitcher />
                     <NavUser />
                 </div>
             </div>

--- a/src/assets/js/components/theme-switcher.tsx
+++ b/src/assets/js/components/theme-switcher.tsx
@@ -1,0 +1,43 @@
+import { Appearance, useAppearance } from '@/hooks/use-appearance';
+import { Button } from './ui/button';
+import { Icon } from './icon';
+import { Moon, Sun, Monitor } from 'lucide-react';
+
+export function ThemeSwitcher() {
+    const { appearance, updateAppearance } = useAppearance();
+
+    const handleChange = (mode: Appearance) => () => updateAppearance(mode);
+
+    const buttonVariant = (mode: Appearance) => (appearance === mode ? 'secondary' : 'ghost');
+
+    return (
+        <div className="flex gap-1">
+            <Button
+                variant={buttonVariant('light')}
+                size="icon"
+                onClick={handleChange('light')}
+                className="shrink-0"
+            >
+                <Icon iconNode={Sun} />
+            </Button>
+            <Button
+                variant={buttonVariant('dark')}
+                size="icon"
+                onClick={handleChange('dark')}
+                className="shrink-0"
+            >
+                <Icon iconNode={Moon} />
+            </Button>
+            <Button
+                variant={buttonVariant('system')}
+                size="icon"
+                onClick={handleChange('system')}
+                className="shrink-0"
+            >
+                <Icon iconNode={Monitor} />
+            </Button>
+        </div>
+    );
+}
+
+export default ThemeSwitcher;

--- a/src/assets/js/hooks/use-appearance.tsx
+++ b/src/assets/js/hooks/use-appearance.tsx
@@ -67,7 +67,7 @@ export function useAppearance() {
 
     useEffect(() => {
         const savedAppearance = localStorage.getItem('appearance') as Appearance | null;
-        updateAppearance(savedAppearance || 'light');
+        updateAppearance(savedAppearance || 'system');
 
         // Listen for localStorage changes (from other tabs)
         const handleStorageChange = (e: StorageEvent) => {


### PR DESCRIPTION
## Summary
- create a ThemeSwitcher component with light, dark and system modes
- update AppSidebarHeader to use ThemeSwitcher
- default to 'system' appearance on first load
- document theme selection and link from docs index
- log new feature in HISTORY

## Testing
- `npm install --legacy-peer-deps`
- `npm run dev` *(fails: Cannot find module '/workspace/adminizer/dist/lib/Adminizer')*
- `npm run build` *(fails: Cannot find module '/workspace/adminizer/dist/lib/Adminizer')*

------
https://chatgpt.com/codex/tasks/task_e_685f600688f083259407de2ab984c4e7