### PR TITLE
Add Lucide icon usage docs

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,0 +1,4 @@
+## 4.1.2
+- Added documentation on assigning icons using the Lucide set.
+- Updated widget example to reference Lucide icons.
+

--- a/docs/Configuration/Widgets.md
+++ b/docs/Configuration/Widgets.md
@@ -4,7 +4,7 @@ This is an example of customizing a custom widget (CustomOne) in a React applica
 - This is a widget class (`CustomOne`) that extends a base widget class (`CustomBase`).
 - It defines metadata for the widget, such as:
     - `id`, `name`, `description`, and `department` (e.g., `"test"`)
-    - `icon` (using a Material icon name, `"takeout_dining"`)
+    - `icon` (using a Lucide icon name, `"activity"`)
     - Default `size` (height and width in grid units)
     - `backgroundCSS` (a light gray color)
 - It specifies JavaScript paths for **development** (direct `.tsx` file) and **production** (a compiled `.es.js` file).

--- a/docs/Icons.md
+++ b/docs/Icons.md
@@ -1,0 +1,43 @@
+[Back](index.md)
+# Icon Usage
+
+Adminizer relies on the [Lucide](https://lucide.dev/icons/) icon set for UI elements. Icons are loaded globally so external modules can use them without additional imports.
+
+## Finding Icons
+Browse the available icons at [lucide.dev/icons](https://lucide.dev/icons/) and note the name of the icon you want to use. For example `activity`, `user`, or `rocket`.
+
+## Assigning Icons in Configuration
+Specify the icon name in your Adminizer configuration. The icon is referenced by its id from Lucide:
+
+```javascript
+module.exports.adminpanel = {
+    models: {
+        post: {
+            title: 'Posts',
+            icon: 'file-text', // Name from lucide.dev
+        }
+    }
+};
+```
+
+## Using Icons in Components
+Icons are also accessible in React components via the `lucide-react` package or through the global object. Example using a direct import:
+
+```tsx
+import { Activity } from 'lucide-react';
+
+export function MyButton() {
+    return <Activity />;
+}
+```
+
+The same icon is available globally as `window.lucide.Activity`, enabling usage inside external modules:
+
+```tsx
+export function External() {
+    const { Activity } = window.lucide;
+    return <Activity />;
+}
+```
+
+These global exports allow modules outside of Adminizer to reuse the same icon set.

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,7 @@
 ## Other
 
 * [Localization](Configuration/Localization.md)
+* [Icons](Icons.md)
 ## 3. Frontend Integration
 
 * [Inertia Adapter & Flash](InertiaAdapter.md)


### PR DESCRIPTION
## Summary
- document using Lucide icons
- reference new icon guide from index
- update widget docs to mention Lucide icons
- log changes in HISTORY

## Testing
- `npm install --legacy-peer-deps` *(fails: peer dependency conflict resolved)*
- `npm run dev` *(fails: Cannot find module 'reflect-metadata')*
- `npm run build`
- `npm test` *(fails: DataAccessor test)*

------
https://chatgpt.com/codex/tasks/task_e_685f677d19c8832590f1c89b147c8a7c