### PR TITLE
feature fix failing tests

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,3 +8,6 @@
 
 - Added system model tests for Waterline and Sequelize.
 
+
+## 4.2.1
+- Fixed failing tests by adding case-insensitive model lookup and resolving Sequelize association naming conflicts.

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -4,3 +4,5 @@
 - Added system theme option and ThemeSwitcher component.
 - Simplified ThemeSwitcher to a single button cycling through modes.
 - Added tests validating system model registration for Waterline and Sequelize.
+
+- Fixed failing unit tests; updated ORM adapters to handle case-insensitive model names and unique Sequelize associations.

--- a/src/lib/v4/DataAccessor.ts
+++ b/src/lib/v4/DataAccessor.ts
@@ -33,6 +33,13 @@ export class DataAccessor {
 
     }
 
+    private getModelConfig(modelName: string): ModelConfig | undefined {
+        const entry = Object.entries(this.adminizer.config.models)
+            .find(([key]) => key.toLowerCase() === modelName.toLowerCase());
+        const config = entry ? entry[1] : undefined;
+        return isObject(config) ? config as ModelConfig : undefined;
+    }
+
     /**
      * Retrieves the fields for the given entity based on action type,
      * taking into account access rights and configuration settings.
@@ -120,9 +127,12 @@ export class DataAccessor {
                     const model = this.adminizer.modelHandler.model.get(modelName);
                     if (model) {
                         populatedModelFieldsConfig = this.getAssociatedFieldsConfig(modelName);
-                        let _modelConfig = this.adminizer.config.models[modelName];
-                        if(!isObject(_modelConfig)) throw `type error: model config  of ${modelName} is ${typeof(this.adminizer.config.models[modelName])} expected object`
-                        associatedModelConfig = _modelConfig
+                        const modelCfg = this.getModelConfig(modelName);
+                        if (modelCfg) {
+                            associatedModelConfig = modelCfg;
+                        } else {
+                            Adminizer.log.error(`DataAccessor > getFieldsConfig > Model config not found: ${modelName}`);
+                        }
                     } else {
                         Adminizer.log.error(`DataAccessor > getFieldsConfig > Model not found: ${modelName} when ${key}`);
                     }
@@ -148,7 +158,8 @@ export class DataAccessor {
     private getAssociatedFieldsConfig(modelName: string): { [fieldName: string]: Field } | undefined {
         
         const model = this.adminizer.modelHandler.model.get(modelName);
-        if (!model || !this.adminizer.config.models[modelName] || typeof this.adminizer.config.models[modelName] === "boolean") {
+        const modelConfig = this.getModelConfig(modelName);
+        if (!model || !modelConfig) {
             return undefined;
         }
 
@@ -160,9 +171,6 @@ export class DataAccessor {
         }
 
         const associatedFields: { [fieldName: string]: Field } = {};
-        const modelConfig = this.adminizer.config.models[modelName];
-
-        if(!isObject(modelConfig)) throw `Type error ModelConfig should is object`
         // Get the main fields configuration
         const fieldsConfig = modelConfig.fields || {};
 

--- a/src/lib/v4/model/adapter/sequelize.ts
+++ b/src/lib/v4/model/adapter/sequelize.ts
@@ -36,15 +36,25 @@ function generateAssociationsFromSchema(
         }
         // 💡 O:M связь (один ко многим)
         else {
-          const foreignKey = field.collection === modelName ? field.via : `${modelName}Id`;
+          let foreignKey = `${modelName}Id`;
+          if (field.collection === modelName) {
+            foreignKey = `${field.via}Id`;
+          }
+
           model.hasMany(targetModel, {
             as: fieldName,
             foreignKey,
           });
-          targetModel.belongsTo(model, {
-            as: field.via,
-            foreignKey,
-          });
+
+          const alias = field.via;
+          const belongsToOptions = { foreignKey } as any;
+          if (targetModel.rawAttributes[alias]) {
+            belongsToOptions.as = `${alias}Ref`;
+          } else {
+            belongsToOptions.as = alias;
+          }
+
+          targetModel.belongsTo(model, belongsToOptions);
         }
       }
 
@@ -57,15 +67,15 @@ function generateAssociationsFromSchema(
         const foreignKey = `${fieldName}Id`;
         const alias = fieldName;
 
-        // Если поле уже существует — избегаем конфликта
+        // If attribute with the same name already exists, use a unique alias to avoid collisions
         if (model.rawAttributes[alias]) {
           model.belongsTo(targetModel, {
-            as: alias,
+            as: `${alias}Ref`,
             foreignKey,
           });
         } else {
           model.belongsTo(targetModel, {
-            foreignKey: alias, // если нет конфликта, можно использовать alias как FK
+            foreignKey: alias,
           });
         }
       }

--- a/src/lib/v4/model/adapter/waterline.ts
+++ b/src/lib/v4/model/adapter/waterline.ts
@@ -100,11 +100,19 @@ export class WaterlineAdapter extends AbstractAdapter {
   }
 
   getModel(modelName: string): Record<string, any> {
-    return this.orm.ontology.collections[modelName];
+    const matchedKey = Object.keys(this.orm.ontology.collections).find(
+      key => key.toLowerCase() === modelName.toLowerCase()
+    );
+
+    if (!matchedKey) {
+      return undefined;
+    }
+
+    return this.orm.ontology.collections[matchedKey];
   }
 
   getAttributes(modelName: string): Waterline.Attributes {
-    const model = this.orm.ontology.collections[modelName];
+    const model = this.getModel(modelName);
     if (!model) {
       throw new Error(`Model "${modelName}" was not found`);
     }
@@ -128,7 +136,7 @@ export class WaterlineAdapter extends AbstractAdapter {
       const modelName = path.basename(file).replace(/\.(ts|js)$/, "");
       const systemModelPath = path.resolve(systemModelsDir, file);
       const adminizerModel = (await import(pathToFileURL(systemModelPath).href)).default;
-      const waterlineLikeModel = generateWaterlineModel(modelName, adminizerModel);
+      const waterlineLikeModel = generateWaterlineModel(modelName, structuredClone(adminizerModel));
 
       // Register model in Waterline ORM
       waterlineORM.registerModel(waterlineLikeModel);


### PR DESCRIPTION
## Summary
- fix case-insensitive model lookup for Waterline
- avoid association naming collisions in Sequelize adapter
- add helper for retrieving model config
- clone system model definitions before mutation
- document the changes in HISTORY

## Testing
- `npm test`
- `npm run build`
- `npm start` *(fails before manual stop but shows startup logs)*

------
https://chatgpt.com/codex/tasks/task_e_685f9da324008325a4ed45cf3692c67a