### PR TITLE
fix sequelize naming collision

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,6 @@
 
+## 4.2.1
+- Renamed MediaManager parent association to `parent` to resolve Sequelize naming collision.
 ## 4.1.4
 - Fixed Sequelize system model registration errors in tests.
 ## 4.1.3

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -5,3 +5,4 @@
 - Added system theme option and ThemeSwitcher component.
 - Simplified ThemeSwitcher to a single button cycling through modes.
 - Added tests validating system model registration for Waterline and Sequelize.
+- Fixed naming collision in MediaManager models by renaming the parent association.

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -47,4 +47,22 @@ Install the `material-icons` package so the CSS can be resolved:
 npm install material-icons --legacy-peer-deps
 ```
 
+### Naming Collision Between Attributes and Associations in Sequelize
+
+**Description:**
+
+Starting the application may fail with an error similar to:
+
+```
+Error: Naming collision between attribute 'parentNode' and association 'parentNode' on model MediaManagerAP
+```
+
+**Cause:**
+
+Both an attribute and an association shared the alias `parentNode` in the `MediaManagerAP` model. Sequelize treats association aliases as properties on the model, so duplicate names are not allowed.
+
+**Solution:**
+
+Rename the association or attribute so that they use unique names. In version 4.2.1, the `parentNode` association has been renamed to `parent` across the related models.
+
 

--- a/src/models/MediaManagerAP.ts
+++ b/src/models/MediaManagerAP.ts
@@ -9,12 +9,12 @@ export default {
     primaryKey: true,
     required: true
   },
-  parentNode: {
+  parent: {
     model: "MediaManagerAP"
   },
   variants: {
     collection: "MediaManagerAP",
-    via: "parentNode"
+    via: "parent"
   },
   mimeType: { 
     type: "string"
@@ -39,7 +39,7 @@ export default {
   },
   meta: {
     collection: "MediaManagerMetaAP",
-    via: "parentNode"
+    via: "parent"
   },
   modelAssociation: {
     collection: "MediaManagerAssociationsAP",
@@ -48,7 +48,7 @@ export default {
 }
 export interface MediaManagerAP {
   id: string;
-  parentNode?: MediaManagerAP;
+  parent?: MediaManagerAP;
   variants?: MediaManagerAP[];
   mimeType?: string;
   path?: string;

--- a/src/models/MediaManagerMetaAP.ts
+++ b/src/models/MediaManagerMetaAP.ts
@@ -17,7 +17,7 @@ export default {
   isPublic: {
     type: "boolean"
   },
-  parentNode: {
+  parent: {
     model: "MediaManagerAP"
   }
 }
@@ -28,5 +28,5 @@ export interface MediaManagerMetaAP {
   key?: string;
   value?: Record<string, unknown>;
   isPublic?: boolean;
-  parentNode?: MediaManagerAP;
+  parent?: MediaManagerAP;
 }


### PR DESCRIPTION
## Summary
- rename `parentNode` association to `parent`
- document Sequelize naming collision in troubleshooting guide
- log change in HISTORY

## Testing
- `npm test`
- `npm run build`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_685fa94dccd88325ae1de92c93fdfb27