### PR TITLE
Fix naming collision for MediaManagerAP

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,3 +11,4 @@
 
 - Added system model tests for Waterline and Sequelize.
 
+- Resolved Sequelize naming collision for MediaManagerAP parent associations.

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -5,3 +5,4 @@
 - Added system theme option and ThemeSwitcher component.
 - Simplified ThemeSwitcher to a single button cycling through modes.
 - Added tests validating system model registration for Waterline and Sequelize.
+- Fixed naming collision for self-referential MediaManagerAP associations.

--- a/src/lib/v4/model/adapter/sequelize.ts
+++ b/src/lib/v4/model/adapter/sequelize.ts
@@ -36,7 +36,9 @@ function generateAssociationsFromSchema(
         }
         // 💡 O:M связь (один ко многим)
         else {
-          const foreignKey = field.collection === modelName ? field.via : `${modelName}Id`;
+          const foreignKey = field.collection === modelName
+            ? `${field.via}Id`
+            : `${modelName}Id`;
           model.hasMany(targetModel, {
             as: fieldName,
             foreignKey,


### PR DESCRIPTION
## Summary
- handle self-referential associations with explicit `parentNodeId` foreign key
- document the fix

## Testing
- `npm run build`
- `npm test`
- `npm start` (then CTRL+C)

------
https://chatgpt.com/codex/tasks/task_e_685fa94dccd88325ae1de92c93fdfb27