### PR TITLE
Fix sequelize self reference naming

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,6 @@
 
+## 4.1.5
+- Fixed naming collision error for `MediaManagerAP` when registering Sequelize models.
 ## 4.1.4
 - Fixed Sequelize system model registration errors in tests.
 ## 4.1.3

--- a/docs/Configuration/Models.md
+++ b/docs/Configuration/Models.md
@@ -13,3 +13,5 @@ The provided models are:
 
 They can be created and queried like any other models once registered.
 
+When defining self‑referencing relationships, ensure that the foreign key uses a unique column name such as `parentNodeId`. Adminizer's Sequelize adapter automatically handles this and assigns an alias like `parentNode` without conflicting with the attribute name.
+

--- a/src/lib/v4/model/adapter/sequelize.ts
+++ b/src/lib/v4/model/adapter/sequelize.ts
@@ -36,12 +36,18 @@ function generateAssociationsFromSchema(
         }
         // 💡 O:M связь (один ко многим)
         else {
-          const foreignKey = field.collection === modelName ? field.via : `${modelName}Id`;
+          const foreignKey =
+            field.collection === modelName ? `${field.via}Id` : `${modelName}Id`;
+
           model.hasMany(targetModel, {
             as: fieldName,
             foreignKey,
           });
-          const belongsAlias = model.rawAttributes[field.via] ? `${field.via}Assoc` : field.via;
+
+          const belongsAlias = targetModel.rawAttributes[field.via]
+            ? `${field.via}Assoc`
+            : field.via;
+
           if (!targetModel.associations[belongsAlias]) {
             targetModel.belongsTo(model, {
               as: belongsAlias,


### PR DESCRIPTION
## Summary
- avoid naming collision on MediaManagerAP associations
- document self-referencing models
- log change in HISTORY

## Testing
- `npm test`
- `npm run build`
- `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_685fa94dccd88325ae1de92c93fdfb27