### PR TITLE
feature: fix sequelize naming collisions

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,3 +11,6 @@
 
 ## 4.2.1
 - Fixed failing tests by adding case-insensitive model lookup and resolving Sequelize association naming conflicts.
+
+## 4.2.2
+- Explicit foreign key names now avoid collisions between attributes and associations in Sequelize.

--- a/docs/Configuration/Models.md
+++ b/docs/Configuration/Models.md
@@ -13,3 +13,7 @@ The provided models are:
 
 They can be created and queried like any other models once registered.
 
+When using Sequelize the adapter generates explicit foreign keys using the
+`<fieldName>Id` pattern. This prevents naming collisions between attributes and
+associations when models reference themselves or each other.
+

--- a/src/lib/v4/model/adapter/sequelize.ts
+++ b/src/lib/v4/model/adapter/sequelize.ts
@@ -48,7 +48,7 @@ function generateAssociationsFromSchema(
 
           const alias = field.via;
           const belongsToOptions = { foreignKey } as any;
-          if (targetModel.rawAttributes[alias]) {
+          if (targetModel.rawAttributes[alias] || targetModel.associations[alias]) {
             belongsToOptions.as = `${alias}Ref`;
           } else {
             belongsToOptions.as = alias;
@@ -63,21 +63,20 @@ function generateAssociationsFromSchema(
         const targetModel = models[field.model];
         if (!targetModel) continue;
 
-        // Avoid naming collision by making FK explicit: `${fieldName}Id`
-        const foreignKey = `${fieldName}Id`;
+        // Avoid naming collisions by using an explicit foreign key
         const alias = fieldName;
+        const foreignKey = `${alias}Id`;
 
-        // If attribute with the same name already exists, use a unique alias to avoid collisions
-        if (model.rawAttributes[alias]) {
-          model.belongsTo(targetModel, {
-            as: `${alias}Ref`,
-            foreignKey,
-          });
-        } else {
-          model.belongsTo(targetModel, {
-            foreignKey: alias,
-          });
+        // Reuse the attribute name unless it already exists on the model or association
+        let asName = alias;
+        if (model.rawAttributes[alias] || model.associations[alias]) {
+          asName = `${alias}Ref`;
         }
+
+        model.belongsTo(targetModel, {
+          as: asName,
+          foreignKey,
+        });
       }
     }
   }


### PR DESCRIPTION
## Summary
- avoid alias collisions when generating Sequelize associations
- document explicit foreign key naming for Sequelize
- note alias fix in HISTORY

## Testing
- `npm run build:backend`
- `npm run start`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685fa9530f6c83258c29b123a5f1c0da