### PR TITLE
Fix self-referential Sequelize naming collision

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,3 +11,6 @@
 
 ## 4.2.1
 - Fixed failing tests by adding case-insensitive model lookup and resolving Sequelize association naming conflicts.
+
+## 4.2.2
+- Fixed naming collision for self-referential Sequelize models.

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -6,3 +6,4 @@
 - Added tests validating system model registration for Waterline and Sequelize.
 
 - Fixed failing unit tests; updated ORM adapters to handle case-insensitive model names and unique Sequelize associations.
+- Fixed naming collision for Sequelize self-referential models.

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -48,3 +48,16 @@ npm install material-icons --legacy-peer-deps
 ```
 
 
+### Sequelize Self-Relation Naming Collision
+
+**Description:**
+
+When a model references itself using both `model` and `collection` fields, Sequelize may throw an error:
+
+```
+Error: Naming collision between attribute 'parentNode' and association 'parentNode'
+```
+
+**Solution:**
+
+Upgrade to version 4.2.2 or later, which automatically assigns unique aliases for self-referential associations.

--- a/src/lib/v4/model/adapter/sequelize.ts
+++ b/src/lib/v4/model/adapter/sequelize.ts
@@ -48,7 +48,7 @@ function generateAssociationsFromSchema(
 
           const alias = field.via;
           const belongsToOptions = { foreignKey } as any;
-          if (targetModel.rawAttributes[alias]) {
+          if (targetModel.rawAttributes[alias] || targetModel.associations[alias]) {
             belongsToOptions.as = `${alias}Ref`;
           } else {
             belongsToOptions.as = alias;
@@ -63,21 +63,16 @@ function generateAssociationsFromSchema(
         const targetModel = models[field.model];
         if (!targetModel) continue;
 
-        // Avoid naming collision by making FK explicit: `${fieldName}Id`
-        const foreignKey = `${fieldName}Id`;
         const alias = fieldName;
+        const foreignKey = `${fieldName}Id`;
 
-        // If attribute with the same name already exists, use a unique alias to avoid collisions
-        if (model.rawAttributes[alias]) {
-          model.belongsTo(targetModel, {
-            as: `${alias}Ref`,
-            foreignKey,
-          });
-        } else {
-          model.belongsTo(targetModel, {
-            foreignKey: alias,
-          });
+        const belongsToOptions: any = { foreignKey, as: alias };
+
+        if (model.rawAttributes[alias] || model.associations[alias]) {
+          belongsToOptions.as = `${alias}Ref`;
         }
+
+        model.belongsTo(targetModel, belongsToOptions);
       }
     }
   }


### PR DESCRIPTION
## Summary
- handle self-referential belongsTo associations in `generateAssociationsFromSchema`
- document the fix in HISTORY and Troubleshooting docs

## Testing
- `npm run build:backend`
- `npm test`
- `npm run build`
- `npm start` *(server starts then Ctrl-C)*

------
https://chatgpt.com/codex/tasks/task_e_685fa9530f6c83258c29b123a5f1c0da