### PR TITLE
Fix Sequelize parentNode alias collision

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,3 +11,6 @@
 
 ## 4.2.1
 - Fixed failing tests by adding case-insensitive model lookup and resolving Sequelize association naming conflicts.
+
+## 4.2.2
+- Fixed Sequelize naming collision for parentNode relation.

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -6,3 +6,4 @@
 - Added tests validating system model registration for Waterline and Sequelize.
 
 - Fixed failing unit tests; updated ORM adapters to handle case-insensitive model names and unique Sequelize associations.
+- Fixed Sequelize naming collision for `parentNode` association.

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -48,3 +48,17 @@ npm install material-icons --legacy-peer-deps
 ```
 
 
+### Association Naming Collision in Sequelize
+
+**Description:**
+
+Running the fixture with Sequelize may produce an error:
+
+```
+Error: Naming collision between attribute 'parentNode' and association 'parentNode' on model MediaManagerAP
+```
+
+**Solution:**
+
+Upgrade to the latest version or apply the fix that sets a dedicated alias and foreign key (`parentNodeId`) for the `parentNode` relation. This prevents Sequelize from generating a conflicting attribute name.
+

--- a/src/lib/v4/model/adapter/sequelize.ts
+++ b/src/lib/v4/model/adapter/sequelize.ts
@@ -48,7 +48,7 @@ function generateAssociationsFromSchema(
 
           const alias = field.via;
           const belongsToOptions = { foreignKey } as any;
-          if (targetModel.rawAttributes[alias]) {
+          if (targetModel.rawAttributes[alias] || targetModel.associations[alias]) {
             belongsToOptions.as = `${alias}Ref`;
           } else {
             belongsToOptions.as = alias;
@@ -67,15 +67,17 @@ function generateAssociationsFromSchema(
         const foreignKey = `${fieldName}Id`;
         const alias = fieldName;
 
-        // If attribute with the same name already exists, use a unique alias to avoid collisions
-        if (model.rawAttributes[alias]) {
+        // If attribute or association with the same name already exists
+        // use a unique alias to avoid collisions
+        if (model.rawAttributes[alias] || model.associations[alias]) {
           model.belongsTo(targetModel, {
             as: `${alias}Ref`,
             foreignKey,
           });
         } else {
           model.belongsTo(targetModel, {
-            foreignKey: alias,
+            as: alias,
+            foreignKey,
           });
         }
       }


### PR DESCRIPTION
## Summary
- avoid Sequelize association name collisions
- document how to resolve the parentNode alias conflict in Sequelize
- note fix in change log

## Testing
- `npm test`
- `npm start`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685fa9530f6c83258c29b123a5f1c0da