### PR TITLE
Fix Sequelize naming collision

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,3 +9,4 @@
 - Added system model tests for Waterline and Sequelize.
 
 - Fixed test suite reliability by normalizing model lookups and adjusting Sequelize association handling. Sequelize tests temporarily skipped.
+- Fixed fixture imports to use TypeScript sources and documented Sequelize parentNode collision.

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -5,3 +5,4 @@
 - Simplified ThemeSwitcher to a single button cycling through modes.
 - Added tests validating system model registration for Waterline and Sequelize.
 - Updated tests documentation with instructions on skipping unstable Sequelize suite.
+- Updated fixture to import from `src` and added troubleshooting note about Sequelize naming collision.

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -48,3 +48,28 @@ npm install material-icons --legacy-peer-deps
 ```
 
 
+
+### Sequelize `parentNode` Naming Collision
+
+**Description:**
+
+Launching the fixture with Sequelize may throw the following error:
+
+```
+Error: Naming collision between attribute 'parentNode' and association 'parentNode' on model MediaManagerAP
+```
+
+**Cause:**
+
+Older builds compiled the ORM adapter with a `parentNode` field that conflicted with the generated association. If the `dist` directory is stale, Sequelize fails when registering models.
+
+**Solution:**
+
+Use the TypeScript sources directly or rebuild the project before starting the fixture:
+
+```bash
+npm run build
+npm start
+```
+
+The adapter now assigns foreign keys with a `Id` suffix (e.g., `parentNodeId`) which prevents this collision.

--- a/fixture/adminizerConfig.ts
+++ b/fixture/adminizerConfig.ts
@@ -1,4 +1,4 @@
-import {AdminpanelConfig} from "../dist/interfaces/adminpanelConfig";
+import {AdminpanelConfig} from "../src/interfaces/adminpanelConfig";
 import Example from "./models/Example";
 
 const routePrefix = "/adminizer";

--- a/fixture/index.ts
+++ b/fixture/index.ts
@@ -1,6 +1,6 @@
-import {Adminizer} from "../dist/lib/Adminizer";
+import {Adminizer} from "../src/lib/Adminizer";
 import http from 'http';
-import {WaterlineAdapter, WaterlineModel} from "../dist/lib/v4/model/adapter/waterline";
+import {WaterlineAdapter, WaterlineModel} from "../src/lib/v4/model/adapter/waterline";
 import Waterline from "waterline";
 import waterlineConfig from "./waterlineConfig";
 import ExampleWaterline from "./models/Example";
@@ -12,7 +12,7 @@ import CatalogPageNav from "./models/CatalogPageNav";
 import GroupCatalog from "./models/GroupCatalog";
 import UserWaterline from "./models/User";
 import adminpanelConfig from "./adminizerConfig";
-import {AdminpanelConfig} from "../dist/interfaces/adminpanelConfig";
+import {AdminpanelConfig} from "../src/interfaces/adminpanelConfig";
 
 import {ReactQuill} from "../modules/controls/wysiwyg/ReactQuill";
 
@@ -27,7 +27,7 @@ import {JsonSchema as JsonSchemaSequelize} from "./models/sequelize/JsonSchema";
 import {Test as TestSequelize} from "./models/sequelize/Test";
 import {Category as CategorySequelize} from "./models/sequelize/Category";
 import {TestCatalog as TestCatalogSequelize} from "./models/sequelize/TestCatalog";
-import {SequelizeAdapter} from "../dist/lib/v4/model/adapter/sequelize";
+import {SequelizeAdapter} from "../src/lib/v4/model/adapter/sequelize";
 import {seedDatabase} from "./helpers/seedDatabase";
 
 
@@ -38,7 +38,7 @@ import {InfoOne, Info4, Info3, InfoTwo} from "./widgets/Info";
 import {CustomOne} from "./widgets/Custom";
 import {ActionOne, ActionTwo} from "./widgets/Actions";
 import {TestCatalog} from "./virtual-catalog/virtualCatalog";
-import {CatalogHandler} from "../dist/lib/v4/catalog/CatalogHandler";
+import {CatalogHandler} from "../src/lib/v4/catalog/CatalogHandler";
 
 process.env.AP_PASSWORD_SALT = "FIXTURE"
 

--- a/fixture/virtual-catalog/virtualCatalog.ts
+++ b/fixture/virtual-catalog/virtualCatalog.ts
@@ -4,10 +4,10 @@ import {
     AbstractItem,
     ActionHandler,
     Item
-} from "../../dist/lib/v4/catalog/AbstractCatalog";
-import {Adminizer} from "../../dist";
+} from "../../src/lib/v4/catalog/AbstractCatalog";
+import {Adminizer} from "../../src";
 import {v4 as uuid} from "uuid";
-import {NavItem, StorageServices} from "../../dist/lib/v4/catalog/Navigation";
+import {NavItem, StorageServices} from "../../src/lib/v4/catalog/Navigation";
 
 interface TestItem extends Item {
     modelId?: string

--- a/fixture/widgets/Actions.ts
+++ b/fixture/widgets/Actions.ts
@@ -1,4 +1,4 @@
-import ActionBase from "../../dist/lib/v4/widgets/abstractAction";
+import ActionBase from "../../src/lib/v4/widgets/abstractAction";
 
 export class ActionOne extends  ActionBase{
     icon?: string;

--- a/fixture/widgets/Custom.ts
+++ b/fixture/widgets/Custom.ts
@@ -1,4 +1,4 @@
-import CustomBase from '../../dist/lib/v4/widgets/abstractCustom';
+import CustomBase from '../../src/lib/v4/widgets/abstractCustom';
 
 export class CustomOne extends CustomBase {
     jsPath: { dev: string; production: string; } = {

--- a/fixture/widgets/Info.ts
+++ b/fixture/widgets/Info.ts
@@ -1,4 +1,4 @@
-import InfoBase from "../../dist/lib/v4/widgets/abstractInfo";
+import InfoBase from "../../src/lib/v4/widgets/abstractInfo";
 
 export class InfoOne extends InfoBase {
     icon?: string;

--- a/fixture/widgets/Links.ts
+++ b/fixture/widgets/Links.ts
@@ -1,4 +1,4 @@
-import LinkBase, {Links} from "../../dist/lib/v4/widgets/abstractLink";
+import LinkBase, {Links} from "../../src/lib/v4/widgets/abstractLink";
 
 export class SiteLinks extends LinkBase {
     icon?: string;

--- a/fixture/widgets/Switchers.ts
+++ b/fixture/widgets/Switchers.ts
@@ -1,4 +1,4 @@
-import SwitchBase from "../../dist/lib/v4/widgets/abstractSwitch";
+import SwitchBase from "../../src/lib/v4/widgets/abstractSwitch";
 
 export class SwitcherOne extends SwitchBase {
 	readonly id: string = 'site_switcher';


### PR DESCRIPTION
## Summary
- import adminizer sources directly in fixture
- document Sequelize `parentNode` naming collision and fix
- log fix in HISTORY

## Testing
- `npm test`
- `npm run build`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_685fa958115c832580e2eb26cb9ded4e