### PR TITLE
Fix naming collision in Sequelize generator

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,3 +9,5 @@
 - Added system model tests for Waterline and Sequelize.
 
 - Fixed test suite reliability by normalizing model lookups and adjusting Sequelize association handling. Sequelize tests temporarily skipped.
+
+- Resolved Sequelize naming collision for parentNode associations

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -5,3 +5,5 @@
 - Simplified ThemeSwitcher to a single button cycling through modes.
 - Added tests validating system model registration for Waterline and Sequelize.
 - Updated tests documentation with instructions on skipping unstable Sequelize suite.
+
+- Fixed naming collision issue when registering MediaManagerAP in Sequelize.

--- a/src/lib/v4/model/adapter/sequelize.ts
+++ b/src/lib/v4/model/adapter/sequelize.ts
@@ -59,7 +59,7 @@ function generateAssociationsFromSchema(
         const foreignKey = `${fieldName}Id`;
         const alias = fieldName;
 
-        if (!model.associations[alias]) {
+        if (!model.associations[alias] && !Object.prototype.hasOwnProperty.call(model.rawAttributes, alias)) {
           model.belongsTo(targetModel, {
             as: alias,
             foreignKey,


### PR DESCRIPTION
## Summary
- avoid collision when creating MediaManagerAP associations
- document the Sequelize fix

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fa958115c832580e2eb26cb9ded4e