### PR TITLE
feat(view): add dedicated view components

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,8 @@
 
 ## 4.2.1
 - Renamed MediaManager parent association to `parent` to resolve Sequelize naming collision.
+## 4.2.2
+- Added read-only view pages and control `viewPath` option.
 ## 4.1.4
 - Fixed Sequelize system model registration errors in tests.
 ## 4.1.3

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -1,4 +1,5 @@
 # Change Log
+- Added dedicated view pages and `viewPath` control support.
 - Fixed Sequelize system model registration errors in tests.
 - Documented material-icons dependency and build step.
 

--- a/docs/ViewComponents.md
+++ b/docs/ViewComponents.md
@@ -1,0 +1,16 @@
+# View Components
+
+The admin panel now exposes separate React pages for viewing model records.
+These components reuse the existing forms with all inputs disabled. Custom
+controls can provide dedicated read-only components by supplying a `viewPath`
+option.
+
+## Pages
+- `view.tsx` – generic view page using `AddForm` in read-only mode.
+- `view-user.tsx` – view page for the User model.
+- `view-group.tsx` – view page for the Group model.
+
+## Usage
+Server controllers render these pages when handling the `view` action. If a
+control does not provide a custom `viewPath`, the default edit control is used
+with input disabled.

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,3 +32,4 @@
 * [Role & Group Management](AccessControl/RoleGroups.md)
 * [Global UI Components](GlobalUI.md)
 * [UI Component List](UIComponents.md)
+* [View Components](ViewComponents.md)

--- a/src/assets/js/components/add-form.tsx
+++ b/src/assets/js/components/add-form.tsx
@@ -47,9 +47,10 @@ const LazyField: FC<{
     value: FieldValue;
     onChange: (name: string, value: FieldValue) => void;
     processing: boolean;
+    view: boolean;
     notFound?: string
     search?: string
-}> = memo(({field, value, onChange, processing, notFound, search}) => {
+}> = memo(({field, value, onChange, processing, view, notFound, search}) => {
     const [ref, inView] = useInView({
         triggerOnce: true,
         rootMargin: '100px 0px',
@@ -65,6 +66,7 @@ const LazyField: FC<{
                     notFound={notFound}
                     search={search}
                     processing={processing}
+                    view={view}
                 />
             ) : <Skeleton className="w-full h-[250px] rounded-sm"/>}
         </div>
@@ -164,6 +166,7 @@ const AddForm: FC<{
                                                 value={data[field.name]}
                                                 onChange={handleFieldChange}
                                                 processing={catalogProcessing || processing || view}
+                                                view={view}
                                                 notFound={notFound}
                                                 search={page.props.search}
                                             />
@@ -177,6 +180,7 @@ const AddForm: FC<{
                                                 value={data[field.name]}
                                                 onChange={handleFieldChange}
                                                 processing={catalogProcessing || processing || view}
+                                                view={view}
                                                 notFound={notFound}
                                                 search={page.props.search}
                                             />

--- a/src/assets/js/components/field-renderer.tsx
+++ b/src/assets/js/components/field-renderer.tsx
@@ -29,9 +29,10 @@ const FieldRenderer: FC<{
     value: FieldValue;
     onChange: (name: string, value: FieldValue) => void;
     processing: boolean;
+    view?: boolean;
     notFound?: string
     search?: string
-}> = memo(({field, value, onChange, processing, notFound, search}) => {
+}> = memo(({field, value, onChange, processing, view = false, notFound, search}) => {
 
     const handleInputChange = useCallback(
         (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
@@ -99,12 +100,20 @@ const FieldRenderer: FC<{
         return ''
     }, []);
 
+    if (view && field.options?.viewPath) {
+        return (
+            <DynamicControls moduleComponent={field.options.viewPath as string} options={field.options?.config}
+                             initialValue={value as string ?? ''} name={`${field.type}-${field.name}`}
+                             onChange={() => {}} disabled={true}/>
+        )
+    }
+
     switch (field.type) {
         case 'checkbox':
             return (
                 <Checkbox
                     id={`${field.type}-${field.name}`}
-                    disabled={processing || field.disabled}
+                    disabled={processing || view || field.disabled}
                     tabIndex={1}
                     required={field.required}
                     className="cursor-pointer size-5"
@@ -117,7 +126,7 @@ const FieldRenderer: FC<{
                 <Textarea
                     id={`${field.type}-${field.name}`}
                     tabIndex={1}
-                    disabled={processing || field.disabled}
+                    disabled={processing || view || field.disabled}
                     value={value as string ?? ''}
                     required={field.required}
                     onChange={handleInputChange}
@@ -136,7 +145,7 @@ const FieldRenderer: FC<{
                         step={1}
                         id={`${field.type}-${field.name}`}
                         onValueChange={handleSliderChange}
-                        disabled={processing || field.disabled}
+                        disabled={processing || view || field.disabled}
                     />
                 </>
             );
@@ -145,7 +154,7 @@ const FieldRenderer: FC<{
                 <Select
                     onValueChange={handleSelectChange}
                     defaultValue={value as string ?? ''}
-                    disabled={processing || field.disabled}
+                    disabled={processing || view || field.disabled}
                     required={field.required}
                 >
                     <SelectTrigger className="w-full cursor-pointer min-h-10" id={field.name}>
@@ -171,7 +180,7 @@ const FieldRenderer: FC<{
                     variant="secondary"
                     notFound={notFound}
                     search={search}
-                    disabled={processing || field.disabled}
+                    disabled={processing || view || field.disabled}
                     mode={field.type === 'association' ? 'single' : 'multiple'}
                     maxCount={10}
                     className={`${processing ? 'pointer-events-none' : ''}`}
@@ -184,67 +193,67 @@ const FieldRenderer: FC<{
                         initialValue={value as string ?? ''}
                         onChange={handleEditorChange}
                         options={field.options?.config as { items: string[] }}
-                        disabled={processing || field.disabled}
+                        disabled={processing || view || field.disabled}
                     />
                 )
             } else {
                 return (
                     <DynamicControls moduleComponent={field.options?.path as string} options={field.options?.config}
                                      initialValue={value as string ?? ''} name={`${field.type}-${field.name}`}
-                                     onChange={handleEditorChange} disabled={processing || field.disabled}/>
+                                     onChange={handleEditorChange} disabled={processing || view || field.disabled}/>
                 )
             }
         case 'markdown':
             if (field.options?.name === 'toast-ui') {
                 return (
                     <TuiLazy initialValue={field.value as string ?? ''} options={field.options?.config}
-                             onChange={handleEditorChange} disabled={processing || field.disabled}/>
+                             onChange={handleEditorChange} disabled={processing || view || field.disabled}/>
                 )
             } else {
                 return (
                     <DynamicControls moduleComponent={field.options?.path as string} options={field.options?.config}
                                      initialValue={value as string ?? ''} name={`${field.type}-${field.name}`}
-                                     onChange={handleEditorChange} disabled={processing || field.disabled}/>
+                                     onChange={handleEditorChange} disabled={processing || view || field.disabled}/>
                 )
             }
         case 'table':
             if (field.options?.name === 'handsontable') {
                 return (
                     <HandsonTableLazy data={value as any[]} config={field.options?.config}
-                                      onChange={handleTableChange} disabled={processing || field.disabled}/>
+                                      onChange={handleTableChange} disabled={processing || view || field.disabled}/>
                 )
             } else {
                 return (
                     <DynamicControls moduleComponent={field.options?.path as string} options={field.options?.config}
                                      initialValue={value as string ?? ''} name={`${field.type}-${field.name}`}
-                                     onChange={handleEditorChange} disabled={processing || field.disabled}/>
+                                     onChange={handleEditorChange} disabled={processing || view || field.disabled}/>
                 )
             }
         case 'jsonEditor':
             if (field.options?.name === 'jsoneditor') {
                 return (
                     <JsonEditorLazy content={value as Content} name={`${field.type}-${field.name}`}
-                                    onChange={handleJSONChange} {...field.options?.config} disabled={processing || field.disabled}
+                                    onChange={handleJSONChange} {...field.options?.config} disabled={processing || view || field.disabled}
                     />
                 )
             } else {
                 return (
                     <DynamicControls moduleComponent={field.options?.path as string} options={field.options?.config}
                                      initialValue={value as string ?? ''} name={`${field.type}-${field.name}`}
-                                     onChange={handleJSONChange} disabled={processing || field.disabled}/>
+                                     onChange={handleJSONChange} disabled={processing || view || field.disabled}/>
                 )
             }
         case 'codeEditor':
             if (field.options?.name === 'monaco') {
                 return (
                     <MonacoLazy value={value as string ?? ''} onChange={handleCodeChange}
-                                options={field.options?.config} disabled={processing || field.disabled}/>
+                                options={field.options?.config} disabled={processing || view || field.disabled}/>
                 )
             } else {
                 return (
                     <DynamicControls moduleComponent={field.options?.path as string} options={field.options?.config}
                                      initialValue={value as string ?? ''} name={`${field.type}-${field.name}`}
-                                     onChange={handleJSONChange} disabled={processing || field.disabled}/>
+                                     onChange={handleJSONChange} disabled={processing || view || field.disabled}/>
                 )
             }
         case 'geoJson':
@@ -254,14 +263,14 @@ const FieldRenderer: FC<{
                         mode="all"
                         initialFeatures={value as [] ?? undefined}
                         onFeaturesChange={handleGeoJsonChange}
-                        disabled={processing || field.disabled}
+                        disabled={processing || view || field.disabled}
                     />
                 )
             } else {
                 return (
                     <DynamicControls moduleComponent={field.options?.path as string} options={field.options?.config}
                                      initialValue={value as string ?? ''} name={`${field.type}-${field.name}`}
-                                     onChange={handleJSONChange} disabled={processing || field.disabled}/>
+                                     onChange={handleJSONChange} disabled={processing || view || field.disabled}/>
                 )
             }
         case 'mediamanager':
@@ -278,7 +287,7 @@ const FieldRenderer: FC<{
                     tabIndex={1}
                     value={value as any ?? ''}
                     onChange={handleInputChange}
-                    disabled={processing || field.disabled}
+                    disabled={processing || view || field.disabled}
                     placeholder={field.label}
                 />
             );

--- a/src/assets/js/pages/view-group.tsx
+++ b/src/assets/js/pages/view-group.tsx
@@ -1,0 +1,13 @@
+import {type BreadcrumbItem} from "@/types";
+import AppLayout from "@/layouts/app-layout.tsx";
+import AddGroupForm from "@/components/add-group-form.tsx";
+
+const breadcrumbs: BreadcrumbItem[] = [];
+
+export default function ViewGroup() {
+    return (
+        <AppLayout breadcrumbs={breadcrumbs}>
+            <AddGroupForm />
+        </AppLayout>
+    );
+}

--- a/src/assets/js/pages/view-user.tsx
+++ b/src/assets/js/pages/view-user.tsx
@@ -1,0 +1,13 @@
+import {type BreadcrumbItem} from "@/types";
+import AppLayout from "@/layouts/app-layout.tsx";
+import AddUserForm from "@/components/add-user-form.tsx";
+
+const breadcrumbs: BreadcrumbItem[] = [];
+
+export default function ViewUser() {
+    return (
+        <AppLayout breadcrumbs={breadcrumbs}>
+            <AddUserForm />
+        </AppLayout>
+    );
+}

--- a/src/assets/js/pages/view.tsx
+++ b/src/assets/js/pages/view.tsx
@@ -1,0 +1,16 @@
+import {type BreadcrumbItem} from "@/types";
+import AppLayout from "@/layouts/app-layout.tsx";
+import AddForm from "@/components/add-form.tsx";
+import {usePage} from "@inertiajs/react";
+import type {AddProps} from "./add";
+
+const breadcrumbs: BreadcrumbItem[] = [];
+
+export default function View() {
+    const page = usePage<AddProps>();
+    return (
+        <AppLayout breadcrumbs={breadcrumbs}>
+            <AddForm page={page} catalog={false}/>
+        </AppLayout>
+    );
+}

--- a/src/controllers/view.ts
+++ b/src/controllers/view.ts
@@ -56,7 +56,7 @@ export default async function view(req: ReqType, res: ResType) {
             }
             const userProps = inertiaUserHelper(entity, req, groups, record as UserAP, true)
             return req.Inertia.render({
-                component: 'add-user',
+                component: 'view-user',
                 props: userProps
             })
 
@@ -88,7 +88,7 @@ export default async function view(req: ReqType, res: ResType) {
             }
             const groupProps = inertiaGroupHelper(entity, req, users, groupedTokens, group, true)
             return req.Inertia.render({
-                component: 'add-group',
+                component: 'view-group',
                 props: groupProps
             })
 
@@ -96,7 +96,7 @@ export default async function view(req: ReqType, res: ResType) {
             fields = await FieldsHelper.loadAssociations(req, fields, "edit");
             const props = inertiaAddHelper(req, entity, fields, record, true)
             return req.Inertia.render({
-                component: 'add',
+                component: 'view',
                 props: props
             })
     }

--- a/src/helpers/inertiaAddHelper.ts
+++ b/src/helpers/inertiaAddHelper.ts
@@ -185,6 +185,7 @@ export function getControlsOptions(fieldConfig: Field["config"], req: ReqType, t
             ...(fieldOptions?.config || {}), // Additional config provided in the field config
         },
         path: control?.getJsPath() || {},
+        viewPath: control?.getViewJsPath() || control?.getJsPath() || {},
     };
 
     if (type === 'wysiwyg') {
@@ -192,6 +193,7 @@ export function getControlsOptions(fieldConfig: Field["config"], req: ReqType, t
             name: editorName,
             config: control?.getConfig() || {},
             path: control?.getJsPath() || {},
+            viewPath: control?.getViewJsPath() || control?.getJsPath() || {},
         };
 
         // If items are provided, use them instead of the editor's config

--- a/src/lib/v4/controls/AbstractControls.ts
+++ b/src/lib/v4/controls/AbstractControls.ts
@@ -38,4 +38,11 @@ export abstract class AbstractControls {
     public abstract getCssPath(): string | undefined
 
     public abstract getName(): string
+
+    /**
+     * Returns JS path for view mode component. By default it matches getJsPath.
+     */
+    public getViewJsPath(): string | undefined {
+        return this.getJsPath();
+    }
 }


### PR DESCRIPTION
## Summary
- add a `getViewJsPath` method in `AbstractControls`
- expose `viewPath` from `inertiaAddHelper`
- allow `FieldRenderer` to handle read-only view
- extend `AddForm` to forward view state
- implement `view`, `view-user`, and `view-group` pages
- document view components and update change logs

## Testing
- `npm ci` *(fails: could not resolve peer dependency)*
- `npm run start` *(fails: cross-env not found)*
- `npm run build` *(fails: cannot find package 'shelljs')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68635eb3f2648325957e89b7705ca7c2