### PR TITLE
feature: view component support

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -19,3 +19,4 @@
 
 ## 4.2.2
 - Explicit foreign key names now avoid collisions between attributes and associations in Sequelize.
+- Introduced dedicated view pages and viewPath support for controls

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -7,3 +7,4 @@
 - Added tests validating system model registration for Waterline and Sequelize.
 
 - Fixed failing unit tests; updated ORM adapters to handle case-insensitive model names and unique Sequelize associations.
+- Added view component and optional view controls

--- a/docs/ViewComponent.md
+++ b/docs/ViewComponent.md
@@ -1,0 +1,7 @@
+# View Component
+
+Adminizer now provides a separate view component used to display model data.
+
+Controls can optionally provide a `viewPath` that points to a read only UI
+module. When no custom view control is specified the default disabled input is
+used.

--- a/modules/controls/wysiwyg/ReactQuill.ts
+++ b/modules/controls/wysiwyg/ReactQuill.ts
@@ -10,7 +10,11 @@ export class ReactQuill extends AbstractControls {
             {
                 dev: "/modules/controls/wysiwyg/react-quill-editor.tsx",
                 production: `${this.routPrefix}/assets/modules/react-quill-editor.es.js`
-            }
+            },
+        viewJsPath: {
+            dev: "/modules/controls/wysiwyg/react-quill-editor.tsx",
+            production: `${this.routPrefix}/assets/modules/react-quill-editor.es.js`
+        }
     }
     readonly config: Config = {};
 
@@ -27,6 +31,14 @@ export class ReactQuill extends AbstractControls {
             return this.path.jsPath.dev;
         } else {
             return this.path.jsPath.production
+        }
+    }
+
+    getViewJsPath(): string {
+        if (process.env.VITE_ENV === 'dev') {
+            return this.path.viewJsPath!.dev;
+        } else {
+            return this.path.viewJsPath!.production;
         }
     }
 

--- a/src/assets/js/components/add-form.tsx
+++ b/src/assets/js/components/add-form.tsx
@@ -49,7 +49,8 @@ const LazyField: FC<{
     processing: boolean;
     notFound?: string
     search?: string
-}> = memo(({field, value, onChange, processing, notFound, search}) => {
+    view: boolean
+}> = memo(({field, value, onChange, processing, notFound, search, view}) => {
     const [ref, inView] = useInView({
         triggerOnce: true,
         rootMargin: '100px 0px',
@@ -65,6 +66,7 @@ const LazyField: FC<{
                     notFound={notFound}
                     search={search}
                     processing={processing}
+                    view={view}
                 />
             ) : <Skeleton className="w-full h-[250px] rounded-sm"/>}
         </div>
@@ -166,6 +168,7 @@ const AddForm: FC<{
                                                 processing={catalogProcessing || processing || view}
                                                 notFound={notFound}
                                                 search={page.props.search}
+                                                view={page.props.view}
                                             />
                                         </>
                                         :
@@ -177,6 +180,7 @@ const AddForm: FC<{
                                                 value={data[field.name]}
                                                 onChange={handleFieldChange}
                                                 processing={catalogProcessing || processing || view}
+                                                view={page.props.view}
                                                 notFound={notFound}
                                                 search={page.props.search}
                                             />

--- a/src/assets/js/components/field-renderer.tsx
+++ b/src/assets/js/components/field-renderer.tsx
@@ -31,7 +31,8 @@ const FieldRenderer: FC<{
     processing: boolean;
     notFound?: string
     search?: string
-}> = memo(({field, value, onChange, processing, notFound, search}) => {
+    view?: boolean
+}> = memo(({field, value, onChange, processing, notFound, search, view}) => {
 
     const handleInputChange = useCallback(
         (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
@@ -189,7 +190,7 @@ const FieldRenderer: FC<{
                 )
             } else {
                 return (
-                    <DynamicControls moduleComponent={field.options?.path as string} options={field.options?.config}
+                    <DynamicControls moduleComponent={(view && field.options?.viewPath ? field.options?.viewPath : field.options?.path) as string} options={field.options?.config}
                                      initialValue={value as string ?? ''} name={`${field.type}-${field.name}`}
                                      onChange={handleEditorChange} disabled={processing || field.disabled}/>
                 )
@@ -202,7 +203,7 @@ const FieldRenderer: FC<{
                 )
             } else {
                 return (
-                    <DynamicControls moduleComponent={field.options?.path as string} options={field.options?.config}
+                    <DynamicControls moduleComponent={(view && field.options?.viewPath ? field.options?.viewPath : field.options?.path) as string} options={field.options?.config}
                                      initialValue={value as string ?? ''} name={`${field.type}-${field.name}`}
                                      onChange={handleEditorChange} disabled={processing || field.disabled}/>
                 )
@@ -215,7 +216,7 @@ const FieldRenderer: FC<{
                 )
             } else {
                 return (
-                    <DynamicControls moduleComponent={field.options?.path as string} options={field.options?.config}
+                    <DynamicControls moduleComponent={(view && field.options?.viewPath ? field.options?.viewPath : field.options?.path) as string} options={field.options?.config}
                                      initialValue={value as string ?? ''} name={`${field.type}-${field.name}`}
                                      onChange={handleEditorChange} disabled={processing || field.disabled}/>
                 )
@@ -229,7 +230,7 @@ const FieldRenderer: FC<{
                 )
             } else {
                 return (
-                    <DynamicControls moduleComponent={field.options?.path as string} options={field.options?.config}
+                    <DynamicControls moduleComponent={(view && field.options?.viewPath ? field.options?.viewPath : field.options?.path) as string} options={field.options?.config}
                                      initialValue={value as string ?? ''} name={`${field.type}-${field.name}`}
                                      onChange={handleJSONChange} disabled={processing || field.disabled}/>
                 )
@@ -242,7 +243,7 @@ const FieldRenderer: FC<{
                 )
             } else {
                 return (
-                    <DynamicControls moduleComponent={field.options?.path as string} options={field.options?.config}
+                    <DynamicControls moduleComponent={(view && field.options?.viewPath ? field.options?.viewPath : field.options?.path) as string} options={field.options?.config}
                                      initialValue={value as string ?? ''} name={`${field.type}-${field.name}`}
                                      onChange={handleJSONChange} disabled={processing || field.disabled}/>
                 )
@@ -259,7 +260,7 @@ const FieldRenderer: FC<{
                 )
             } else {
                 return (
-                    <DynamicControls moduleComponent={field.options?.path as string} options={field.options?.config}
+                    <DynamicControls moduleComponent={(view && field.options?.viewPath ? field.options?.viewPath : field.options?.path) as string} options={field.options?.config}
                                      initialValue={value as string ?? ''} name={`${field.type}-${field.name}`}
                                      onChange={handleJSONChange} disabled={processing || field.disabled}/>
                 )

--- a/src/assets/js/components/view-form.tsx
+++ b/src/assets/js/components/view-form.tsx
@@ -1,0 +1,41 @@
+import {FC} from "react";
+import {Field} from "@/types";
+import {Label} from "@/components/ui/label.tsx";
+import FieldRenderer from "@/components/field-renderer.tsx";
+import {Button} from "@/components/ui/button.tsx";
+import {Link} from "@inertiajs/react";
+import {Icon} from "@/components/icon.tsx";
+import {MoveLeft} from "lucide-react";
+import InputError from "@/components/input-error.tsx";
+import {getFieldError} from '@/hooks/form-state';
+
+export interface ViewFormProps {
+    page: { props: { fields: Field[]; btnBack: { title: string; link: string; }; view: boolean; notFound?: string; search?: string; } };
+}
+
+const ViewForm: FC<ViewFormProps> = ({page}) => {
+    const {fields, btnBack, notFound} = page.props;
+    return (
+        <div className="p-4 w-full">
+            <div className="w-full sticky z-[1001] py-4 pb-8 top-0 h-fit bg-background flex gap-4">
+                <Button className="w-fit" asChild>
+                    <Link href={btnBack.link} preserveScroll={true}>
+                        <Icon iconNode={MoveLeft}/>
+                        {btnBack.title}
+                    </Link>
+                </Button>
+            </div>
+            <div className="grid gap-4 max-w-[1144px]">
+                {fields.map((field) => (
+                    <div className="grid gap-4 w-full" key={field.name}>
+                        <Label htmlFor={`${field.type}-${field.name}`}>{field.label}</Label>
+                        <InputError message={getFieldError(`${field.type}-${field.name}`)}/>
+                        <FieldRenderer field={{...field, disabled: true}} value={field.value} onChange={() => {}} processing={true} notFound={notFound} search={page.props.search}/>
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+};
+
+export default ViewForm;

--- a/src/assets/js/pages/view-group.tsx
+++ b/src/assets/js/pages/view-group.tsx
@@ -1,0 +1,13 @@
+import {type BreadcrumbItem} from "@/types";
+import AppLayout from "@/layouts/app-layout.tsx";
+import AddGroupForm from "@/components/add-group-form.tsx";
+
+const breadcrumbs: BreadcrumbItem[] = [];
+
+export default function ViewGroup() {
+    return (
+        <AppLayout breadcrumbs={breadcrumbs}>
+            <AddGroupForm />
+        </AppLayout>
+    )
+}

--- a/src/assets/js/pages/view-user.tsx
+++ b/src/assets/js/pages/view-user.tsx
@@ -1,0 +1,13 @@
+import {type BreadcrumbItem} from "@/types";
+import AppLayout from "@/layouts/app-layout.tsx";
+import AddUserForm from "@/components/add-user-form.tsx";
+
+const breadcrumbs: BreadcrumbItem[] = [];
+
+export default function ViewUser() {
+    return (
+        <AppLayout breadcrumbs={breadcrumbs}>
+            <AddUserForm />
+        </AppLayout>
+    )
+}

--- a/src/assets/js/pages/view.tsx
+++ b/src/assets/js/pages/view.tsx
@@ -1,0 +1,38 @@
+import {type BreadcrumbItem, Field} from "@/types";
+import AppLayout from "@/layouts/app-layout.tsx";
+import ViewForm from "@/components/view-form.tsx";
+import {usePage} from "@inertiajs/react";
+
+export interface ViewProps {
+    actions: {
+        link: string;
+        id: string;
+        title: string;
+        icon: string;
+    }[];
+    notFound?: string
+    search?: string,
+    btnBack: {
+        title: string;
+        link: string;
+    };
+    fields: Field[];
+    edit: boolean;
+    view: boolean;
+    btnSave: {
+        title: string;
+    },
+    postLink: string,
+    [key: string]: unknown;
+}
+
+const breadcrumbs: BreadcrumbItem[] = [];
+
+export default function View() {
+    const page = usePage<ViewProps>();
+    return (
+        <AppLayout breadcrumbs={breadcrumbs}>
+            <ViewForm page={page} />
+        </AppLayout>
+    )
+}

--- a/src/controllers/view.ts
+++ b/src/controllers/view.ts
@@ -56,7 +56,7 @@ export default async function view(req: ReqType, res: ResType) {
             }
             const userProps = inertiaUserHelper(entity, req, groups, record as UserAP, true)
             return req.Inertia.render({
-                component: 'add-user',
+                component: 'view-user',
                 props: userProps
             })
 
@@ -88,7 +88,7 @@ export default async function view(req: ReqType, res: ResType) {
             }
             const groupProps = inertiaGroupHelper(entity, req, users, groupedTokens, group, true)
             return req.Inertia.render({
-                component: 'add-group',
+                component: 'view-group',
                 props: groupProps
             })
 
@@ -96,7 +96,7 @@ export default async function view(req: ReqType, res: ResType) {
             fields = await FieldsHelper.loadAssociations(req, fields, "edit");
             const props = inertiaAddHelper(req, entity, fields, record, true)
             return req.Inertia.render({
-                component: 'add',
+                component: 'view',
                 props: props
             })
     }

--- a/src/helpers/inertiaAddHelper.ts
+++ b/src/helpers/inertiaAddHelper.ts
@@ -185,6 +185,7 @@ export function getControlsOptions(fieldConfig: Field["config"], req: ReqType, t
             ...(fieldOptions?.config || {}), // Additional config provided in the field config
         },
         path: control?.getJsPath() || {},
+        viewPath: control?.getViewJsPath() || {},
     };
 
     if (type === 'wysiwyg') {
@@ -192,6 +193,7 @@ export function getControlsOptions(fieldConfig: Field["config"], req: ReqType, t
             name: editorName,
             config: control?.getConfig() || {},
             path: control?.getJsPath() || {},
+            viewPath: control?.getViewJsPath() || {},
         };
 
         // If items are provided, use them instead of the editor's config

--- a/src/lib/v4/controls/AbstractControls.ts
+++ b/src/lib/v4/controls/AbstractControls.ts
@@ -7,7 +7,11 @@ export interface Path {
         dev: string
         production: string
     },
-    cssPath: string
+    cssPath: string,
+    viewJsPath?: {
+        dev: string
+        production: string
+    }
 }
 
 export type Config = Record<string, string | string[] | object | number | boolean>
@@ -35,6 +39,7 @@ export abstract class AbstractControls {
     public abstract getConfig(): Config | undefined
 
     public abstract getJsPath(): string | undefined
+    public abstract getViewJsPath(): string | undefined
     public abstract getCssPath(): string | undefined
 
     public abstract getName(): string

--- a/src/lib/v4/controls/codeEditor/MonacoEditor.ts
+++ b/src/lib/v4/controls/codeEditor/MonacoEditor.ts
@@ -7,7 +7,8 @@ export class MonacoEditor extends AbstractControls{
     };
     readonly name: string = 'monaco';
     readonly path: Path = {
-        cssPath: "", jsPath: {dev: "", production: ""}
+        cssPath: "", jsPath: {dev: "", production: ""},
+        viewJsPath: {dev: "", production: ""}
     };
     readonly type: ControlType = 'codeEditor';
 
@@ -24,6 +25,10 @@ export class MonacoEditor extends AbstractControls{
     }
 
     getJsPath(): string | undefined {
+        return undefined;
+    }
+
+    getViewJsPath(): string | undefined {
         return undefined;
     }
 

--- a/src/lib/v4/controls/geojsoneditor/GeoEditor.ts
+++ b/src/lib/v4/controls/geojsoneditor/GeoEditor.ts
@@ -7,7 +7,8 @@ export class GeoEditor extends AbstractControls{
     };
     readonly name: string = "leaflet";
     readonly path: Path = {
-        cssPath: "", jsPath: {dev: "", production: ""}
+        cssPath: "", jsPath: {dev: "", production: ""},
+        viewJsPath: {dev: "", production: ""}
     };
     readonly type: ControlType = 'geoJson';
 
@@ -24,6 +25,10 @@ export class GeoEditor extends AbstractControls{
     }
 
     getJsPath(): string | undefined {
+        return undefined;
+    }
+
+    getViewJsPath(): string | undefined {
         return undefined;
     }
 

--- a/src/lib/v4/controls/jsoneditor/JsonEditor.ts
+++ b/src/lib/v4/controls/jsoneditor/JsonEditor.ts
@@ -11,7 +11,8 @@ export class JsonEditor extends AbstractControls{
             {
                 dev: "",
                 production: ""
-            }
+            },
+        viewJsPath: {dev: "", production: ""}
     }
     readonly type: ControlType = 'jsonEditor';
 
@@ -24,6 +25,10 @@ export class JsonEditor extends AbstractControls{
     }
 
     getJsPath(): undefined {
+        return undefined;
+    }
+
+    getViewJsPath(): undefined {
         return undefined;
     }
 

--- a/src/lib/v4/controls/markdown/ToastUiEditor.ts
+++ b/src/lib/v4/controls/markdown/ToastUiEditor.ts
@@ -16,7 +16,8 @@ export class ToastUiEditor extends AbstractControls{
             {
                 dev: "",
                 production: ""
-            }
+            },
+        viewJsPath: {dev: "", production: ""}
     }
     readonly type: ControlType = 'markdown';
 
@@ -29,6 +30,10 @@ export class ToastUiEditor extends AbstractControls{
     }
 
     getJsPath(): undefined {
+        return undefined;
+    }
+
+    getViewJsPath(): undefined {
         return undefined;
     }
 

--- a/src/lib/v4/controls/table/Handsontable.ts
+++ b/src/lib/v4/controls/table/Handsontable.ts
@@ -17,7 +17,11 @@ export class Handsontable extends AbstractControls{
             {
                 dev: "",
                 production: ""
-            }
+            },
+        viewJsPath: {
+            dev: "",
+            production: ""
+        }
     }
     readonly type: ControlType = 'table';
 
@@ -34,6 +38,10 @@ export class Handsontable extends AbstractControls{
     }
 
     getJsPath(): undefined {
+        return undefined;
+    }
+
+    getViewJsPath(): undefined {
         return undefined;
     }
 

--- a/src/lib/v4/controls/wysiwyg/CKeditor.ts
+++ b/src/lib/v4/controls/wysiwyg/CKeditor.ts
@@ -10,7 +10,8 @@ export class CKeditor extends AbstractControls {
             {
                 dev: "",
                 production: ""
-            }
+            },
+        viewJsPath: {dev: "", production: ""}
     }
     readonly config: Config = {
         items: [
@@ -47,6 +48,10 @@ export class CKeditor extends AbstractControls {
     }
 
     getJsPath(): undefined {
+        return undefined;
+    }
+
+    getViewJsPath(): undefined {
         return undefined;
     }
 


### PR DESCRIPTION
## Summary
- add new View component and pages
- enable optional viewPath for controls
- pass view flag to field renderer
- document new View component

## Testing
- `npm install --legacy-peer-deps`
- `npm run dev` *(fails: Cannot find module '/workspace/adminizer/dist/lib/Adminizer')*
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68635eb3f2648325957e89b7705ca7c2