### PR TITLE
Add AI assistant scaffold with header UI and backend APIs

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,5 @@
+## 4.4.0
+- Added configurable AI assistant with in-memory conversations, backend API endpoints, and header launcher dialog.
 
 ## 4.2.1
 - Renamed MediaManager parent association to `parent` to resolve Sequelize naming collision.

--- a/docs/ai-assistant.md
+++ b/docs/ai-assistant.md
@@ -1,0 +1,54 @@
+# AI Assistant Integration
+
+The admin panel now ships with an optional AI assistant that can be launched from the header bar via the ✨ sparkles button. The assistant is disabled by default and must be enabled explicitly in the Adminizer configuration.
+
+## Enabling the assistant
+
+Add the `aiAssistant` flag to your admin panel configuration (for example in `config/adminpanel.js`):
+
+```ts
+module.exports = {
+  aiAssistant: {
+    enabled: true,
+  },
+};
+```
+
+Once enabled, Adminizer boots the AI assistant handler during startup and registers the built-in dummy model. Additional models can be registered through the handler API in custom bindings.
+
+## Backend architecture
+
+The backend exposes a lightweight abstraction for AI models:
+
+- `AbstractAIModel` – base class that encapsulates how a model generates responses.
+- `AIAssistantHandler` – central registry that stores model instances and in-memory conversation history.
+- `DummyAIModel` – development placeholder that always returns the `"AI-assistant dummy in development"` response.
+
+New models can extend `AbstractAIModel` and be registered inside a custom binding using `adminizer.aiAssistantHandler.registerModel(model)`.
+
+### API endpoints
+
+When the assistant is enabled the router exposes two endpoints under the configured route prefix:
+
+| Method | Endpoint                                | Description                              |
+|--------|------------------------------------------|------------------------------------------|
+| GET    | `/api/ai-assistant/models`               | Returns the list of registered AI models. |
+| POST   | `/api/ai-assistant/messages`             | Sends a prompt to the selected model and returns the updated conversation history. |
+
+Requests to `/api/ai-assistant/messages` accept a JSON body with `modelId`, `message`, and an optional `conversationId`. The response includes the full conversation with all messages accumulated in memory for the current session.
+
+## Front-end behaviour
+
+When the assistant is enabled the header renders a sparkles icon button. Clicking it opens a dialog that allows administrators to:
+
+1. Select an AI model.
+2. Review the current conversation history.
+3. Submit new prompts.
+
+Conversations are stored only in-memory. Closing the dialog keeps the history until the page is refreshed. Model descriptions are shown to help administrators understand the capabilities of each model.
+
+## Limitations
+
+- The default dummy model only returns a fixed placeholder response.
+- Conversations are not persisted. Restarting the server or refreshing the page clears the history.
+- The assistant respects existing admin policies because all API routes are registered through the Adminizer policy manager.

--- a/src/assets/js/components/ai/AIAssistantLauncher.tsx
+++ b/src/assets/js/components/ai/AIAssistantLauncher.tsx
@@ -1,0 +1,251 @@
+import {useCallback, useEffect, useMemo, useState} from "react";
+import axios from "axios";
+import {Sparkles, LoaderCircle, AlertCircle} from "lucide-react";
+
+import {Button} from "@/components/ui/button";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
+import {Textarea} from "@/components/ui/textarea";
+import {cn} from "@/lib/utils";
+
+interface AssistantModel {
+    id: string;
+    label: string;
+    description?: string;
+}
+
+interface AssistantMessage {
+    id: string;
+    role: "user" | "assistant";
+    content: string;
+    createdAt: string;
+}
+
+interface AssistantConversationResponse {
+    conversationId: string;
+    modelId: string;
+    messages: AssistantMessage[];
+}
+
+export function AIAssistantLauncher() {
+    const [open, setOpen] = useState(false);
+    const [models, setModels] = useState<AssistantModel[]>([]);
+    const [modelsLoading, setModelsLoading] = useState(false);
+    const [selectedModel, setSelectedModel] = useState<string>("");
+    const [conversationId, setConversationId] = useState<string | null>(null);
+    const [messages, setMessages] = useState<AssistantMessage[]>([]);
+    const [prompt, setPrompt] = useState("");
+    const [sending, setSending] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const assistantDescription = useMemo(() => {
+        return models.find(model => model.id === selectedModel)?.description ?? "";
+    }, [models, selectedModel]);
+
+    const resetConversation = useCallback(() => {
+        setConversationId(null);
+        setMessages([]);
+    }, []);
+
+    const fetchModels = useCallback(async () => {
+        setModelsLoading(true);
+        setError(null);
+        try {
+            const response = await axios.get<AssistantModel[]>(`${window.routePrefix}/api/ai-assistant/models`);
+            setModels(response.data);
+            if (response.data.length > 0) {
+                setSelectedModel(prev => prev || response.data[0].id);
+            }
+        } catch (err) {
+            console.error("Failed to load AI assistant models", err);
+            setError("Unable to load AI assistant models.");
+        } finally {
+            setModelsLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        if (open && models.length === 0 && !modelsLoading) {
+            void fetchModels();
+        }
+    }, [open, models.length, modelsLoading, fetchModels]);
+
+    useEffect(() => {
+        if (open) {
+            return;
+        }
+
+        const timeout = setTimeout(() => {
+            setPrompt("");
+            setError(null);
+        }, 200);
+
+        return () => clearTimeout(timeout);
+    }, [open]);
+
+    const handleModelChange = useCallback((value: string) => {
+        setSelectedModel(value);
+        resetConversation();
+    }, [resetConversation]);
+
+    const handleSend = useCallback(async () => {
+        if (!prompt.trim() || !selectedModel) {
+            return;
+        }
+
+        setSending(true);
+        setError(null);
+        try {
+            const response = await axios.post<AssistantConversationResponse>(
+                `${window.routePrefix}/api/ai-assistant/messages`,
+                {
+                    modelId: selectedModel,
+                    message: prompt,
+                    conversationId,
+                }
+            );
+
+            setConversationId(response.data.conversationId);
+            setMessages(response.data.messages);
+            setPrompt("");
+        } catch (err) {
+            console.error("Failed to send AI assistant message", err);
+            setError("Unable to send a request to the AI assistant.");
+        } finally {
+            setSending(false);
+        }
+    }, [prompt, selectedModel, conversationId]);
+
+    const canSend = prompt.trim().length > 0 && Boolean(selectedModel) && !sending;
+
+    return (
+        <Dialog open={open} onOpenChange={setOpen}>
+            <DialogTrigger asChild>
+                <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="h-9 w-9"
+                >
+                    <Sparkles className="size-4" />
+                    <span className="sr-only">Open AI assistant</span>
+                </Button>
+            </DialogTrigger>
+            <DialogContent className="sm:max-w-2xl">
+                <DialogHeader>
+                    <DialogTitle className="flex items-center gap-2">
+                        <Sparkles className="size-4" />
+                        AI assistant
+                    </DialogTitle>
+                    <DialogDescription>
+                        {assistantDescription || "Select a model and describe your task to start a conversation."}
+                    </DialogDescription>
+                </DialogHeader>
+
+                <div className="space-y-4">
+                    <div className="space-y-2">
+                        <label className="text-sm font-medium" htmlFor="ai-assistant-model">
+                            Model
+                        </label>
+                        <Select
+                            value={selectedModel}
+                            onValueChange={handleModelChange}
+                            disabled={modelsLoading || models.length === 0}
+                        >
+                            <SelectTrigger id="ai-assistant-model">
+                                <SelectValue placeholder={modelsLoading ? "Loading models..." : "Choose a model"} />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {models.map(model => (
+                                    <SelectItem key={model.id} value={model.id}>
+                                        {model.label}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                        {!modelsLoading && models.length === 0 && (
+                            <p className="text-xs text-muted-foreground">
+                                No AI models are registered. Ask an administrator to enable one.
+                            </p>
+                        )}
+                    </div>
+
+                    <div className="h-64 rounded-md border bg-muted/40 p-3 overflow-y-auto space-y-3 text-sm">
+                        {messages.length === 0 && (
+                            <p className="text-muted-foreground text-center text-sm">
+                                The conversation is empty. Ask the assistant for help with your task.
+                            </p>
+                        )}
+                        {messages.map(message => (
+                            <div
+                                key={message.id}
+                                className={cn(
+                                    "flex flex-col gap-1",
+                                    message.role === "user" ? "items-end" : "items-start"
+                                )}
+                            >
+                                <span className="text-xs uppercase tracking-wide text-muted-foreground">
+                                    {message.role === "user" ? "You" : "Assistant"}
+                                </span>
+                                <div
+                                    className={cn(
+                                        "rounded-md px-3 py-2",
+                                        message.role === "user"
+                                            ? "bg-primary text-primary-foreground"
+                                            : "bg-background border"
+                                    )}
+                                >
+                                    {message.content}
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+
+                    <div className="space-y-2">
+                        <label className="text-sm font-medium" htmlFor="ai-assistant-input">
+                            Your request
+                        </label>
+                        <Textarea
+                            id="ai-assistant-input"
+                            placeholder="Describe what you need the assistant to do"
+                            rows={4}
+                            value={prompt}
+                            onChange={event => setPrompt(event.target.value)}
+                        />
+                    </div>
+
+                    {error && (
+                        <div className="flex items-center gap-2 text-destructive text-sm">
+                            <AlertCircle className="size-4" />
+                            <span>{error}</span>
+                        </div>
+                    )}
+                </div>
+
+                <DialogFooter className="sm:justify-between">
+                    <div className="text-xs text-muted-foreground">
+                        Conversations are stored temporarily during this session only.
+                    </div>
+                    <Button type="button" onClick={handleSend} disabled={!canSend}>
+                        {sending && <LoaderCircle className="mr-2 size-4 animate-spin" />}
+                        Send
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/src/assets/js/components/app-sidebar-header.tsx
+++ b/src/assets/js/components/app-sidebar-header.tsx
@@ -7,6 +7,7 @@ import {NotificationCenter} from "@/components/notifications/NotificationCenter.
 import {useNotifications} from "@/contexts/NotificationContext.tsx";
 import {LoaderCircle} from "lucide-react";
 import {usePage} from "@inertiajs/react";
+import {AIAssistantLauncher} from "@/components/ai/AIAssistantLauncher";
 
 export function AppSidebarHeader({breadcrumbs = []}: { breadcrumbs?: BreadcrumbItemType[] }) {
     const {tabs} = useNotifications();
@@ -20,6 +21,9 @@ export function AppSidebarHeader({breadcrumbs = []}: { breadcrumbs?: BreadcrumbI
                     <Breadcrumbs breadcrumbs={breadcrumbs}/>
                 </div>
                 <div className="flex gap-4 items-center">
+                    {page.props.aiAssistant && (
+                        <AIAssistantLauncher/>
+                    )}
                     <ThemeSwitcher/>
                     {page.props.notifications && (
                         tabs.length > 0 ?

--- a/src/assets/js/types/index.d.ts
+++ b/src/assets/js/types/index.d.ts
@@ -42,6 +42,7 @@ export interface SharedData {
     flash: Record<FlashMessages, string>;
     auth: Auth;
     notifications: boolean;
+    aiAssistant: boolean;
     [key: string]: unknown;
 }
 

--- a/src/controllers/ai/AIAssistantController.ts
+++ b/src/controllers/ai/AIAssistantController.ts
@@ -1,0 +1,68 @@
+import {Adminizer} from "../../lib/Adminizer";
+
+export class AIAssistantController {
+    private static ensureEnabled(req: ReqType, res: ResType): boolean {
+        if (!req.adminizer.config.aiAssistant?.enabled) {
+            res.status(404).json({error: 'AI assistant is disabled'});
+            return false;
+        }
+
+        if (!req.adminizer.aiAssistantHandler) {
+            Adminizer.log.error('AI assistant handler is not initialized.');
+            res.status(500).json({error: 'AI assistant is not available'});
+            return false;
+        }
+
+        return true;
+    }
+
+    static listModels(req: ReqType, res: ResType) {
+        if (!AIAssistantController.ensureEnabled(req, res)) {
+            return;
+        }
+
+        const models = req.adminizer.aiAssistantHandler.getModels();
+        res.json(models);
+    }
+
+    static async sendMessage(req: ReqType, res: ResType) {
+        if (!AIAssistantController.ensureEnabled(req, res)) {
+            return;
+        }
+
+        if (req.method.toUpperCase() !== 'POST') {
+            res.status(405).json({error: 'Method Not Allowed'});
+            return;
+        }
+
+        const {modelId, message, conversationId = null} = req.body ?? {};
+
+        if (!modelId || typeof modelId !== 'string') {
+            res.status(400).json({error: 'modelId is required'});
+            return;
+        }
+
+        if (!message || typeof message !== 'string') {
+            res.status(400).json({error: 'message is required'});
+            return;
+        }
+
+        try {
+            const conversation = await req.adminizer.aiAssistantHandler.sendMessage(
+                modelId,
+                message,
+                conversationId,
+                req.user?.id ?? null,
+            );
+
+            res.json({
+                conversationId: conversation.id,
+                modelId: conversation.modelId,
+                messages: conversation.messages,
+            });
+        } catch (error) {
+            Adminizer.log.error('AI assistant error', error);
+            res.status(500).json({error: 'Unable to process AI assistant request'});
+        }
+    }
+}

--- a/src/interfaces/adminpanelConfig.ts
+++ b/src/interfaces/adminpanelConfig.ts
@@ -254,6 +254,10 @@ export interface AdminpanelConfig {
     notifications?: {
         enabled: boolean
     }
+
+    aiAssistant?: {
+        enabled: boolean
+    }
 }
 
 export interface ModelConfig {

--- a/src/interfaces/ai.ts
+++ b/src/interfaces/ai.ts
@@ -1,0 +1,21 @@
+import {AIAssistantMessageRole} from "../types/ai";
+
+export interface AIAssistantMessage {
+    id: string;
+    role: AIAssistantMessageRole;
+    content: string;
+    createdAt: string;
+}
+
+export interface AIAssistantConversation {
+    id: string;
+    modelId: string;
+    userId: number | null;
+    messages: AIAssistantMessage[];
+}
+
+export interface AIAssistantModelSummary {
+    id: string;
+    label: string;
+    description?: string;
+}

--- a/src/lib/Adminizer.ts
+++ b/src/lib/Adminizer.ts
@@ -37,6 +37,8 @@ import { NotificationHandler } from './notifications/NotificationHandler';
 import { GeneralNotificationService } from './notifications/GeneralNotificationService';
 import { SystemNotificationService } from './notifications/SystemNotificationService';
 import {bindNotifications} from "../system/bindNotifications";
+import {AIAssistantHandler} from "./ai/AIAssistantHandler";
+import {bindAiAssistant} from "../system/bindAiAssistant";
 import {INotification} from "../interfaces/types";
 
 export class Adminizer {
@@ -57,6 +59,7 @@ export class Adminizer {
     configHelper: ConfigHelper
     menuHelper: MenuHelper
     notificationHandler!: NotificationHandler;
+    aiAssistantHandler!: AIAssistantHandler;
     modelHandler!: ModelHandler
     widgetHandler: WidgetHandler
     vite: ViteDevServer
@@ -282,6 +285,10 @@ export class Adminizer {
 
         // Bind notifications
         if (this.config.notifications.enabled) await bindNotifications(this);
+
+        if (this.config.aiAssistant?.enabled) {
+            bindAiAssistant(this);
+        }
 
         await Router.bind(this); // must be after binding policies and req/res functions
 

--- a/src/lib/ai/AIAssistantHandler.ts
+++ b/src/lib/ai/AIAssistantHandler.ts
@@ -1,0 +1,86 @@
+import {v4 as uuid} from 'uuid';
+import {Adminizer} from "../Adminizer";
+import {AbstractAIModel} from "./AbstractAIModel";
+import {AIAssistantConversation, AIAssistantMessage, AIAssistantModelSummary} from "../../interfaces/ai";
+
+export class AIAssistantHandler {
+    private readonly models: Map<string, AbstractAIModel> = new Map();
+    private readonly conversations: Map<string, AIAssistantConversation> = new Map();
+
+    constructor(private readonly adminizer: Adminizer) {}
+
+    registerModel(model: AbstractAIModel): void {
+        if (this.models.has(model.id)) {
+            Adminizer.log.warn(`AI assistant model with id \`${model.id}\` already registered. Overwriting.`);
+        }
+
+        this.models.set(model.id, model);
+    }
+
+    getModels(): AIAssistantModelSummary[] {
+        return Array.from(this.models.values()).map(model => ({
+            id: model.id,
+            label: model.label,
+            description: model.description,
+        }));
+    }
+
+    async sendMessage(
+        modelId: string,
+        prompt: string,
+        conversationId: string | null,
+        userId: number | null,
+    ): Promise<AIAssistantConversation> {
+        const model = this.models.get(modelId);
+
+        if (!model) {
+            throw new Error(`AI assistant model \`${modelId}\` is not registered.`);
+        }
+
+        let conversation: AIAssistantConversation | undefined;
+
+        if (conversationId) {
+            conversation = this.conversations.get(conversationId);
+
+            if (conversation && conversation.userId !== userId) {
+                conversation = undefined;
+            }
+        }
+
+        if (!conversation) {
+            conversation = {
+                id: uuid(),
+                modelId,
+                userId,
+                messages: [],
+            };
+            this.conversations.set(conversation.id, conversation);
+        } else if (conversation.modelId !== modelId) {
+            conversation.modelId = modelId;
+            conversation.messages = [];
+        }
+
+        const userMessage: AIAssistantMessage = {
+            id: uuid(),
+            role: 'user',
+            content: prompt,
+            createdAt: new Date().toISOString(),
+        };
+
+        conversation.messages.push(userMessage);
+
+        const response = await model.generateResponse(prompt, conversation);
+
+        const assistantMessage: AIAssistantMessage = {
+            id: uuid(),
+            role: 'assistant',
+            content: response,
+            createdAt: new Date().toISOString(),
+        };
+
+        conversation.messages.push(assistantMessage);
+        this.conversations.set(conversation.id, conversation);
+
+        return conversation;
+    }
+}

--- a/src/lib/ai/AbstractAIModel.ts
+++ b/src/lib/ai/AbstractAIModel.ts
@@ -1,0 +1,19 @@
+import {Adminizer} from "../Adminizer";
+import {AIAssistantConversation} from "../../interfaces/ai";
+
+export abstract class AbstractAIModel {
+    protected readonly adminizer: Adminizer;
+
+    constructor(adminizer: Adminizer) {
+        this.adminizer = adminizer;
+    }
+
+    abstract readonly id: string;
+    abstract readonly label: string;
+    abstract readonly description?: string;
+
+    abstract generateResponse(
+        prompt: string,
+        conversation: AIAssistantConversation
+    ): Promise<string>;
+}

--- a/src/lib/ai/models/DummyAIModel.ts
+++ b/src/lib/ai/models/DummyAIModel.ts
@@ -1,0 +1,12 @@
+import {AbstractAIModel} from "../AbstractAIModel";
+import {AIAssistantConversation} from "../../../interfaces/ai";
+
+export class DummyAIModel extends AbstractAIModel {
+    readonly id = 'dummy';
+    readonly label = 'Dummy assistant';
+    readonly description = 'Returns a placeholder response for development environments.';
+
+    async generateResponse(_: string, __: AIAssistantConversation): Promise<string> {
+        return 'AI-assistant dummy in development';
+    }
+}

--- a/src/system/Router.ts
+++ b/src/system/Router.ts
@@ -20,6 +20,7 @@ import {thumbController} from "../controllers/media-manager/ThumbController";
 import {Adminizer} from "../lib/Adminizer";
 import timezones from "../controllers/timezones";
 import {NotificationController} from "../controllers/notifications/NotificationController";
+import {AIAssistantController} from "../controllers/ai/AIAssistantController";
 
 export default class Router {
 
@@ -156,6 +157,18 @@ export default class Router {
             adminizer.app.post(
                 `${adminizer.config.routePrefix}/api/notifications/search`,
                 adminizer.policyManager.bindPolicies(policies, NotificationController.search)
+            );
+        }
+
+        if (adminizer.config.aiAssistant?.enabled) {
+            adminizer.app.get(
+                `${adminizer.config.routePrefix}/api/ai-assistant/models`,
+                adminizer.policyManager.bindPolicies(policies, AIAssistantController.listModels)
+            );
+
+            adminizer.app.post(
+                `${adminizer.config.routePrefix}/api/ai-assistant/messages`,
+                adminizer.policyManager.bindPolicies(policies, AIAssistantController.sendMessage)
             );
         }
         /**

--- a/src/system/bindAiAssistant.ts
+++ b/src/system/bindAiAssistant.ts
@@ -1,0 +1,12 @@
+import {Adminizer} from "../lib/Adminizer";
+import {AIAssistantHandler} from "../lib/ai/AIAssistantHandler";
+import {DummyAIModel} from "../lib/ai/models/DummyAIModel";
+
+export function bindAiAssistant(adminizer: Adminizer): void {
+    adminizer.aiAssistantHandler = new AIAssistantHandler(adminizer);
+
+    const dummyModel = new DummyAIModel(adminizer);
+    adminizer.aiAssistantHandler.registerModel(dummyModel);
+
+    Adminizer.log.info('AI assistant initialized with dummy model.');
+}

--- a/src/system/bindInertia.ts
+++ b/src/system/bindInertia.ts
@@ -155,6 +155,7 @@ export function bindInertia(adminizer: Adminizer) {
             ] : null,
             showVersion: req.adminizer.config.showVersion ?? false,
             notifications: req.adminizer.config.notifications.enabled ?? false,
+            aiAssistant: req.adminizer.config.aiAssistant?.enabled ?? false,
         });
 
         next();

--- a/src/system/defaults.ts
+++ b/src/system/defaults.ts
@@ -154,6 +154,9 @@ let adminpanelConfig: AdminpanelConfig = {
     },
     notifications: {
         enabled: false
+    },
+    aiAssistant: {
+        enabled: false
     }
 }
 

--- a/src/types/ai.ts
+++ b/src/types/ai.ts
@@ -1,0 +1,1 @@
+export type AIAssistantMessageRole = 'user' | 'assistant';


### PR DESCRIPTION
## Summary
- introduce an AI assistant handler with an abstract model base, dummy implementation, and controller endpoints wired through the router and admin initialization
- add configuration defaults, inertia sharing, and shared types so the new sparkles launcher only appears when the assistant is enabled
- build a dialog-based AI assistant launcher UI and document the feature along with a HISTORY entry

## Testing
- npm install --legacy-peer-deps
- npm run build
- npm run dev


------
https://chatgpt.com/codex/tasks/task_e_68d638d91724832aa31698319ff16648