### PR TITLE
Add AI assistant scaffolding and UI toggle

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,7 @@
 
+## Unreleased
+- Added AI assistant framework with dummy model, in-memory conversations, API endpoints, and UI chat toggle in the header.
+
 ## 4.2.1
 - Renamed MediaManager parent association to `parent` to resolve Sequelize naming collision.
 ## 4.1.4

--- a/docs/ai-assistant.md
+++ b/docs/ai-assistant.md
@@ -1,0 +1,30 @@
+# AI Assistant Integration
+
+The AI assistant is disabled by default and can be enabled through the Adminizer configuration. When enabled, a sparkles button appears in the header that opens a side panel chat. Operators can choose an available model and submit prompts. Responses are handled through the `/api/ai/chat` endpoint.
+
+## Configuration
+
+Add the following section to the Adminizer config to enable the assistant:
+
+```ts
+aiAssistant: {
+    enabled: true,
+    defaultModel: 'dummy',
+    models: [
+        {
+            handler: 'relative/path/to/your/model',
+            exportName: 'CustomAiModel',
+            options: { /* optional model options */ }
+        }
+    ]
+}
+```
+
+If no models are supplied, the system registers the built-in development stub (`AI Assistant Dummy`). Each model must extend the `AbstractAiModel` class and will be registered in the `AiAssistantHandler`.
+
+## API Endpoints
+
+- `GET /api/ai/models` — returns available models and the default selection.
+- `POST /api/ai/chat` — sends a prompt to the selected model and returns the updated conversation history kept in memory for the current user.
+
+All responses return message timestamps in ISO format so that the client can format them for display.

--- a/fixture/adminizerConfig.ts
+++ b/fixture/adminizerConfig.ts
@@ -435,6 +435,9 @@ const config: AdminpanelConfig = {
     notifications: {
         enabled: true
     },
+    aiAssistant: {
+        enabled: false,
+    },
     routePrefix: routePrefix,
     // routePrefix: "/admin",
     auth: {

--- a/src/assets/js/components/ai/AiAssistantLauncher.tsx
+++ b/src/assets/js/components/ai/AiAssistantLauncher.tsx
@@ -1,0 +1,217 @@
+import {useEffect, useMemo, useState} from 'react';
+import axios from 'axios';
+import {Button} from "@/components/ui/button.tsx";
+import {
+    Sheet,
+    SheetContent,
+    SheetFooter,
+    SheetHeader,
+    SheetTitle,
+    SheetTrigger,
+} from "@/components/ui/sheet.tsx";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select.tsx";
+import {Textarea} from "@/components/ui/textarea.tsx";
+import {Loader2, Send, Sparkles} from "lucide-react";
+import {usePage} from "@inertiajs/react";
+import {SharedData} from "@/types";
+
+interface AiAssistantMessage {
+    id: string;
+    role: 'user' | 'assistant';
+    content: string;
+    createdAt: string;
+}
+
+interface AiModelSummary {
+    id: string;
+    name: string;
+    description?: string;
+}
+
+export function AiAssistantLauncher() {
+    const page = usePage<SharedData>();
+    const aiConfig = page.props.aiAssistant;
+
+    const [open, setOpen] = useState(false);
+    const [models, setModels] = useState<AiModelSummary[]>(aiConfig?.models ?? []);
+    const [loadingModels, setLoadingModels] = useState(false);
+    const [modelId, setModelId] = useState<string | undefined>(aiConfig?.defaultModel ?? aiConfig?.models?.[0]?.id);
+    const [conversationId, setConversationId] = useState<string | undefined>();
+    const [messages, setMessages] = useState<AiAssistantMessage[]>([]);
+    const [input, setInput] = useState('');
+    const [submitting, setSubmitting] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const activeModel = useMemo(() => models.find((model) => model.id === modelId), [models, modelId]);
+
+    useEffect(() => {
+        if (!open || models.length > 0) {
+            return;
+        }
+        let isMounted = true;
+        const loadModels = async () => {
+            setLoadingModels(true);
+            try {
+                const {data} = await axios.get(`${window.routePrefix}/api/ai/models`);
+                if (!isMounted) return;
+                setModels(data.models ?? []);
+                setModelId((current) => current ?? data.defaultModel ?? data.models?.[0]?.id);
+            } catch (err) {
+                console.error('Failed to load AI models', err);
+                if (isMounted) {
+                    setError('Unable to load AI models right now.');
+                }
+            } finally {
+                if (isMounted) {
+                    setLoadingModels(false);
+                }
+            }
+        };
+        loadModels();
+        return () => {
+            isMounted = false;
+        };
+    }, [open, models.length]);
+
+    const resetConversation = () => {
+        setConversationId(undefined);
+        setMessages([]);
+        setError(null);
+    };
+
+    const handleModelChange = (value: string) => {
+        setModelId(value);
+        resetConversation();
+    };
+
+    const handleSubmit = async (event: React.FormEvent) => {
+        event.preventDefault();
+        if (!input.trim() || !modelId) {
+            return;
+        }
+        setSubmitting(true);
+        setError(null);
+        try {
+            const {data} = await axios.post(`${window.routePrefix}/api/ai/chat`, {
+                message: input,
+                modelId,
+                conversationId,
+            });
+            setConversationId(data.conversationId);
+            setMessages(data.messages ?? []);
+            setInput('');
+        } catch (err) {
+            console.error('Failed to submit AI request', err);
+            setError('The assistant is unavailable. Please try again later.');
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    if (!aiConfig?.enabled) {
+        return null;
+    }
+
+    return (
+        <Sheet open={open} onOpenChange={setOpen}>
+            <SheetTrigger asChild>
+                <Button
+                    variant="ghost"
+                    size="icon"
+                    className="relative"
+                    aria-label="Open AI assistant"
+                >
+                    <Sparkles className="size-5" />
+                </Button>
+            </SheetTrigger>
+            <SheetContent side="right" className="sm:max-w-lg w-full p-0">
+                <SheetHeader className="border-b bg-muted/40">
+                    <div className="flex items-center justify-between gap-2">
+                        <SheetTitle>AI Assistant</SheetTitle>
+                        <Select value={modelId} onValueChange={handleModelChange} disabled={loadingModels || submitting || models.length === 0}>
+                            <SelectTrigger className="min-w-[160px]">
+                                <SelectValue placeholder="Select model" />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {models.map((model) => (
+                                    <SelectItem key={model.id} value={model.id}>
+                                        {model.name}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
+                    {activeModel?.description && (
+                        <p className="text-muted-foreground text-sm">
+                            {activeModel.description}
+                        </p>
+                    )}
+                </SheetHeader>
+                <div className="flex h-full flex-col">
+                    <div className="flex-1 space-y-4 overflow-y-auto px-4 py-4">
+                        {messages.length === 0 ? (
+                            <div className="rounded-md border border-dashed p-6 text-center text-sm text-muted-foreground">
+                                Start a conversation to get help from the assistant.
+                            </div>
+                        ) : (
+                            messages.map((message) => (
+                                <div
+                                    key={message.id}
+                                    className={`flex flex-col gap-1 ${message.role === 'assistant' ? 'items-start' : 'items-end'}`}
+                                >
+                                    <span className="text-xs text-muted-foreground">
+                                        {message.role === 'assistant' ? 'Assistant' : 'You'} · {new Date(message.createdAt).toLocaleTimeString()}
+                                    </span>
+                                    <div
+                                        className={`max-w-full rounded-lg px-3 py-2 text-sm shadow-sm ${
+                                            message.role === 'assistant'
+                                                ? 'bg-muted text-muted-foreground'
+                                                : 'bg-primary text-primary-foreground'
+                                        }`}
+                                    >
+                                        {message.content}
+                                    </div>
+                                </div>
+                            ))
+                        )}
+                    </div>
+                    {error && (
+                        <div className="px-4 text-sm text-destructive">
+                            {error}
+                        </div>
+                    )}
+                    <SheetFooter className="border-t bg-background">
+                        <form onSubmit={handleSubmit} className="flex w-full flex-col gap-3">
+                            <Textarea
+                                value={input}
+                                onChange={(event) => setInput(event.target.value)}
+                                placeholder={loadingModels ? 'Loading models…' : 'Ask me anything about the admin panel…'}
+                                disabled={submitting || loadingModels || models.length === 0}
+                                className="min-h-[120px]"
+                            />
+                            <div className="flex items-center justify-between">
+                                <span className="text-xs text-muted-foreground">
+                                    Responses are generated by the selected AI model.
+                                </span>
+                                <Button type="submit" disabled={submitting || loadingModels || !input.trim() || !modelId}>
+                                    {submitting ? (
+                                        <Loader2 className="mr-2 size-4 animate-spin" />
+                                    ) : (
+                                        <Send className="mr-2 size-4" />
+                                    )}
+                                    Send
+                                </Button>
+                            </div>
+                        </form>
+                    </SheetFooter>
+                </div>
+            </SheetContent>
+        </Sheet>
+    );
+}

--- a/src/assets/js/components/app-sidebar-header.tsx
+++ b/src/assets/js/components/app-sidebar-header.tsx
@@ -7,6 +7,7 @@ import {NotificationCenter} from "@/components/notifications/NotificationCenter.
 import {useNotifications} from "@/contexts/NotificationContext.tsx";
 import {LoaderCircle} from "lucide-react";
 import {usePage} from "@inertiajs/react";
+import {AiAssistantLauncher} from "@/components/ai/AiAssistantLauncher.tsx";
 
 export function AppSidebarHeader({breadcrumbs = []}: { breadcrumbs?: BreadcrumbItemType[] }) {
     const {tabs} = useNotifications();
@@ -21,6 +22,7 @@ export function AppSidebarHeader({breadcrumbs = []}: { breadcrumbs?: BreadcrumbI
                 </div>
                 <div className="flex gap-4 items-center">
                     <ThemeSwitcher/>
+                    <AiAssistantLauncher/>
                     {page.props.notifications && (
                         tabs.length > 0 ?
                             <NotificationCenter/> :

--- a/src/assets/js/types/index.d.ts
+++ b/src/assets/js/types/index.d.ts
@@ -42,6 +42,15 @@ export interface SharedData {
     flash: Record<FlashMessages, string>;
     auth: Auth;
     notifications: boolean;
+    aiAssistant?: {
+        enabled: boolean;
+        defaultModel?: string;
+        models?: {
+            id: string;
+            name: string;
+            description?: string;
+        }[];
+    };
     [key: string]: unknown;
 }
 

--- a/src/controllers/ai/AiAssistantController.ts
+++ b/src/controllers/ai/AiAssistantController.ts
@@ -1,0 +1,57 @@
+export class AiAssistantController {
+    private static ensureEnabled(req: ReqType, res: ResType): boolean {
+        if (!req.adminizer.config.aiAssistant?.enabled || !req.adminizer.aiAssistantHandler) {
+            res.status(404).json({error: 'AI assistant is disabled'});
+            return false;
+        }
+        return true;
+    }
+
+    static listModels(req: ReqType, res: ResType) {
+        if (!AiAssistantController.ensureEnabled(req, res)) {
+            return;
+        }
+        const handler = req.adminizer.aiAssistantHandler!;
+        res.json({
+            models: handler.listModels(),
+            defaultModel: handler.getDefaultModelId(),
+        });
+    }
+
+    static async chat(req: ReqType, res: ResType) {
+        if (!AiAssistantController.ensureEnabled(req, res)) {
+            return;
+        }
+
+        if (req.method.toUpperCase() !== 'POST') {
+            res.status(405).json({error: 'Method not allowed'});
+            return;
+        }
+
+        const {message, modelId, conversationId} = req.body ?? {};
+        const handler = req.adminizer.aiAssistantHandler!;
+
+        try {
+            const result = await handler.processMessage({
+                message,
+                modelId,
+                conversationId,
+                user: req.user,
+            });
+
+            res.json({
+                conversationId: result.conversationId,
+                modelId: result.modelId,
+                messages: result.messages.map(item => ({
+                    id: item.id,
+                    role: item.role,
+                    content: item.content,
+                    createdAt: item.createdAt.toISOString(),
+                })),
+            });
+        } catch (error) {
+            const messageText = error instanceof Error ? error.message : 'Unable to process AI request';
+            res.status(400).json({error: messageText});
+        }
+    }
+}

--- a/src/interfaces/adminpanelConfig.ts
+++ b/src/interfaces/adminpanelConfig.ts
@@ -254,6 +254,16 @@ export interface AdminpanelConfig {
     notifications?: {
         enabled: boolean
     }
+
+    aiAssistant?: {
+        enabled: boolean
+        defaultModel?: string
+        models?: Array<{
+            handler: string
+            exportName?: string
+            options?: Record<string, any>
+        }>
+    }
 }
 
 export interface ModelConfig {

--- a/src/lib/Adminizer.ts
+++ b/src/lib/Adminizer.ts
@@ -37,6 +37,8 @@ import { NotificationHandler } from './notifications/NotificationHandler';
 import { GeneralNotificationService } from './notifications/GeneralNotificationService';
 import { SystemNotificationService } from './notifications/SystemNotificationService';
 import {bindNotifications} from "../system/bindNotifications";
+import {AiAssistantHandler} from "./ai/AiAssistantHandler";
+import {bindAiAssistant} from "../system/bindAiAssistant";
 import {INotification} from "../interfaces/types";
 
 export class Adminizer {
@@ -57,6 +59,7 @@ export class Adminizer {
     configHelper: ConfigHelper
     menuHelper: MenuHelper
     notificationHandler!: NotificationHandler;
+    aiAssistantHandler?: AiAssistantHandler;
     modelHandler!: ModelHandler
     widgetHandler: WidgetHandler
     vite: ViteDevServer
@@ -282,6 +285,9 @@ export class Adminizer {
 
         // Bind notifications
         if (this.config.notifications.enabled) await bindNotifications(this);
+
+        // Bind AI assistant
+        if (this.config.aiAssistant?.enabled) await bindAiAssistant(this);
 
         await Router.bind(this); // must be after binding policies and req/res functions
 

--- a/src/lib/ai/AbstractAiModel.ts
+++ b/src/lib/ai/AbstractAiModel.ts
@@ -1,0 +1,19 @@
+import {Adminizer} from "../Adminizer";
+import {AiConversation, AiMessage} from "./types";
+
+export interface AiGenerationContext {
+    conversation: AiConversation;
+    adminizer: Adminizer;
+}
+
+export abstract class AbstractAiModel {
+    public abstract readonly id: string;
+    public abstract readonly name: string;
+    public readonly description?: string;
+
+    protected constructor(description?: string) {
+        this.description = description;
+    }
+
+    abstract generateReply(prompt: string, context: AiGenerationContext): Promise<AiMessage>;
+}

--- a/src/lib/ai/AiAssistantHandler.ts
+++ b/src/lib/ai/AiAssistantHandler.ts
@@ -1,0 +1,137 @@
+import {v4 as uuid} from "uuid";
+import {Adminizer} from "../Adminizer";
+import {AbstractAiModel, AiGenerationContext} from "./AbstractAiModel";
+import {AiConversation, AiMessage, AiModelSummary} from "./types";
+import {UserAP} from "../../models/UserAP";
+
+export interface ProcessMessageOptions {
+    modelId?: string;
+    message: string;
+    conversationId?: string;
+    user: UserAP;
+}
+
+export interface ProcessMessageResult {
+    conversationId: string;
+    modelId: string;
+    messages: AiMessage[];
+}
+
+export class AiAssistantHandler {
+    private readonly models = new Map<string, AbstractAiModel>();
+    private readonly conversations = new Map<number, Map<string, AiConversation>>();
+    private defaultModelId?: string;
+
+    constructor(private readonly adminizer: Adminizer) {}
+
+    registerModel(model: AbstractAiModel): void {
+        this.models.set(model.id, model);
+        if (!this.defaultModelId) {
+            this.defaultModelId = model.id;
+        }
+    }
+
+    setDefaultModel(modelId: string | undefined): void {
+        if (!modelId) {
+            return;
+        }
+        if (!this.models.has(modelId)) {
+            Adminizer.log.warn(`Attempted to set unknown AI model as default: ${modelId}`);
+            return;
+        }
+        this.defaultModelId = modelId;
+    }
+
+    getDefaultModelId(): string | undefined {
+        return this.defaultModelId;
+    }
+
+    listModels(): AiModelSummary[] {
+        return Array.from(this.models.values()).map((model) => ({
+            id: model.id,
+            name: model.name,
+            description: model.description,
+        }));
+    }
+
+    private getModel(modelId?: string): AbstractAiModel {
+        const effectiveModelId = modelId ?? this.defaultModelId;
+        if (!effectiveModelId) {
+            throw new Error("AI assistant has no registered models");
+        }
+        const model = this.models.get(effectiveModelId);
+        if (!model) {
+            throw new Error(`AI model not found: ${effectiveModelId}`);
+        }
+        return model;
+    }
+
+    private getUserConversations(userId: number): Map<string, AiConversation> {
+        if (!this.conversations.has(userId)) {
+            this.conversations.set(userId, new Map());
+        }
+        return this.conversations.get(userId)!;
+    }
+
+    private getOrCreateConversation(user: UserAP, modelId: string, conversationId?: string): AiConversation {
+        const userConversations = this.getUserConversations(user.id);
+        if (conversationId) {
+            const existing = userConversations.get(conversationId);
+            if (existing) {
+                return existing;
+            }
+        }
+        const newConversation: AiConversation = {
+            id: conversationId ?? uuid(),
+            userId: user.id,
+            modelId,
+            messages: [],
+            updatedAt: new Date(),
+        };
+        userConversations.set(newConversation.id, newConversation);
+        return newConversation;
+    }
+
+    private appendMessage(conversation: AiConversation, message: AiMessage): void {
+        conversation.messages.push(message);
+        conversation.updatedAt = new Date();
+    }
+
+    async processMessage(options: ProcessMessageOptions): Promise<ProcessMessageResult> {
+        const {message, modelId: requestedModelId, conversationId, user} = options;
+        if (!message || !message.trim()) {
+            throw new Error("Message text is required");
+        }
+
+        const model = this.getModel(requestedModelId);
+        const conversation = this.getOrCreateConversation(user, model.id, conversationId);
+
+        if (conversation.modelId !== model.id) {
+            conversation.modelId = model.id;
+            conversation.messages = [];
+        }
+
+        const userMessage: AiMessage = {
+            id: uuid(),
+            role: 'user',
+            content: message,
+            createdAt: new Date(),
+        };
+
+        this.appendMessage(conversation, userMessage);
+
+        const context: AiGenerationContext = {
+            conversation,
+            adminizer: this.adminizer,
+        };
+
+        const assistantMessage = await model.generateReply(message, context);
+        this.appendMessage(conversation, assistantMessage);
+
+        return {
+            conversationId: conversation.id,
+            modelId: conversation.modelId,
+            messages: conversation.messages,
+        };
+    }
+}

--- a/src/lib/ai/models/DummyAiModel.ts
+++ b/src/lib/ai/models/DummyAiModel.ts
@@ -1,0 +1,21 @@
+import {AbstractAiModel, AiGenerationContext} from "../AbstractAiModel";
+import {AiMessage} from "../types";
+import {v4 as uuid} from "uuid";
+
+export class DummyAiModel extends AbstractAiModel {
+    public readonly id = "dummy";
+    public readonly name = "AI Assistant Dummy";
+
+    constructor() {
+        super("Placeholder model used during development");
+    }
+
+    async generateReply(_prompt: string, _context: AiGenerationContext): Promise<AiMessage> {
+        return {
+            id: uuid(),
+            role: 'assistant',
+            content: 'Ai-assystant dummy in deveploment',
+            createdAt: new Date(),
+        };
+    }
+}

--- a/src/lib/ai/types.ts
+++ b/src/lib/ai/types.ts
@@ -1,0 +1,22 @@
+export type AiMessageRole = 'user' | 'assistant';
+
+export interface AiMessage {
+    id: string;
+    role: AiMessageRole;
+    content: string;
+    createdAt: Date;
+}
+
+export interface AiConversation {
+    id: string;
+    userId: number;
+    modelId: string;
+    messages: AiMessage[];
+    updatedAt: Date;
+}
+
+export interface AiModelSummary {
+    id: string;
+    name: string;
+    description?: string;
+}

--- a/src/system/Router.ts
+++ b/src/system/Router.ts
@@ -20,6 +20,7 @@ import {thumbController} from "../controllers/media-manager/ThumbController";
 import {Adminizer} from "../lib/Adminizer";
 import timezones from "../controllers/timezones";
 import {NotificationController} from "../controllers/notifications/NotificationController";
+import {AiAssistantController} from "../controllers/ai/AiAssistantController";
 
 export default class Router {
 
@@ -156,6 +157,17 @@ export default class Router {
             adminizer.app.post(
                 `${adminizer.config.routePrefix}/api/notifications/search`,
                 adminizer.policyManager.bindPolicies(policies, NotificationController.search)
+            );
+        }
+
+        if (adminizer.config.aiAssistant?.enabled) {
+            adminizer.app.get(
+                `${adminizer.config.routePrefix}/api/ai/models`,
+                adminizer.policyManager.bindPolicies(policies, AiAssistantController.listModels)
+            );
+            adminizer.app.post(
+                `${adminizer.config.routePrefix}/api/ai/chat`,
+                adminizer.policyManager.bindPolicies(policies, AiAssistantController.chat)
             );
         }
         /**

--- a/src/system/bindAiAssistant.ts
+++ b/src/system/bindAiAssistant.ts
@@ -1,0 +1,39 @@
+import {Adminizer} from "../lib/Adminizer";
+import {AiAssistantHandler} from "../lib/ai/AiAssistantHandler";
+import {DummyAiModel} from "../lib/ai/models/DummyAiModel";
+import {AbstractAiModel} from "../lib/ai/AbstractAiModel";
+
+export async function bindAiAssistant(adminizer: Adminizer): Promise<void> {
+    adminizer.aiAssistantHandler = new AiAssistantHandler(adminizer);
+    const config = adminizer.config.aiAssistant;
+
+    const configuredModels = config?.models ?? [];
+
+    if (configuredModels.length === 0) {
+        adminizer.aiAssistantHandler.registerModel(new DummyAiModel());
+    } else {
+        for (const modelConfig of configuredModels) {
+            try {
+                if (!modelConfig.handler) {
+                    continue;
+                }
+                const imported = await import(modelConfig.handler);
+                const exportKey = modelConfig.exportName ?? 'default';
+                const ModelClass: new (...args: any[]) => AbstractAiModel = imported.default ?? imported[exportKey];
+                if (!ModelClass) {
+                    Adminizer.log.warn(`AI model handler not found for path: ${modelConfig.handler}`);
+                    continue;
+                }
+                const instance = new ModelClass(adminizer, modelConfig.options ?? {});
+                adminizer.aiAssistantHandler.registerModel(instance);
+            } catch (error) {
+                Adminizer.log.error(`Failed to register AI model from ${modelConfig.handler}`, error);
+            }
+        }
+        if (adminizer.aiAssistantHandler.listModels().length === 0) {
+            adminizer.aiAssistantHandler.registerModel(new DummyAiModel());
+        }
+    }
+
+    adminizer.aiAssistantHandler.setDefaultModel(config?.defaultModel ?? adminizer.aiAssistantHandler.getDefaultModelId());
+}

--- a/src/system/bindInertia.ts
+++ b/src/system/bindInertia.ts
@@ -155,6 +155,11 @@ export function bindInertia(adminizer: Adminizer) {
             ] : null,
             showVersion: req.adminizer.config.showVersion ?? false,
             notifications: req.adminizer.config.notifications.enabled ?? false,
+            aiAssistant: req.adminizer.config.aiAssistant?.enabled ? {
+                enabled: true,
+                defaultModel: req.adminizer.aiAssistantHandler?.getDefaultModelId(),
+                models: req.adminizer.aiAssistantHandler?.listModels() ?? [],
+            } : {enabled: false},
         });
 
         next();

--- a/src/system/defaults.ts
+++ b/src/system/defaults.ts
@@ -154,6 +154,11 @@ let adminpanelConfig: AdminpanelConfig = {
     },
     notifications: {
         enabled: false
+    },
+    aiAssistant: {
+        enabled: false,
+        models: [],
+        defaultModel: undefined,
     }
 }
 


### PR DESCRIPTION
## Summary
- scaffold AI assistant infrastructure with abstract model base, handler, and dummy responder
- expose AI configuration through inertia defaults, router bindings, and share props so the header can render the assistant toggle
- add header launcher sheet UI, documentation, and history entry for the new AI chat capability

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d638d91724832aa31698319ff16648