### PR TITLE
Add AI assistant chat scaffold

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,6 @@
+## 4.3.3
+- Enabled the AI assistant in the demo fixture with dummy model defaults and seeded access tokens for standard users.
+
 ## 4.3.2
 - Added AI assistant chat mode with header toggle, in-memory history, and backend API scaffolding.
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,6 @@
+## 4.3.2
+- Added AI assistant chat mode with header toggle, in-memory history, and backend API scaffolding.
+
 
 ## 4.2.1
 - Renamed MediaManager parent association to `parent` to resolve Sequelize naming collision.

--- a/docs/AiAssistant.md
+++ b/docs/AiAssistant.md
@@ -47,3 +47,10 @@ To register a new model:
 2. Add a factory entry to `modelFactories` in `bindAiAssistant.ts`.
 3. Reference the new model identifier in `aiAssistant.models` within your configuration.
 4. Assign the generated access token (`ai-assistant-<modelId>`) to the user groups that should have access.
+
+## Fixture setup
+
+The demo fixture enables the assistant by default so the sparkles toggle immediately opens the chat. The configuration selects
+the in-memory `dummy` model as both the default and the only registered model. The fixture seeder also grants the `Users` group
+the `ai-assistant-dummy` access token, ensuring that non-administrator accounts can exercise the API endpoints during manual
+testing.

--- a/docs/AiAssistant.md
+++ b/docs/AiAssistant.md
@@ -1,0 +1,49 @@
+# AI Assistant Integration
+
+The AI assistant feature introduces a chat experience that can be toggled from the main header. It is disabled by default and can be enabled through the admin panel configuration.
+
+## Configuration
+
+The `AdminpanelConfig` accepts an optional `aiAssistant` section:
+
+```ts
+aiAssistant?: {
+    enabled: boolean;
+    defaultModel?: string;
+    models?: string[];
+}
+```
+
+* `enabled` — toggles the feature on or off (defaults to `false`).
+* `defaultModel` — preferred model identifier that will be preselected on the client.
+* `models` — list of model identifiers to register. Unknown identifiers are ignored with a warning.
+
+The default configuration registers the in-memory `dummy` model that always replies with `Ai-assystant dummy in deveploment`.
+
+## Backend Overview
+
+* `AiAssistantHandler` keeps registered model services and in-memory conversation history per user and model.
+* Model services extend `AbstractAiModelService`, which automatically registers the corresponding access right (token pattern: `ai-assistant-<modelId>`).
+* The binder (`bindAiAssistant`) attaches the handler to `Adminizer` and registers models declared in the configuration.
+* `AiAssistantController` exposes REST endpoints under `/api/ai-assistant` for:
+  * Listing available models (`GET /models`).
+  * Fetching conversation history (`GET /history/:modelId`).
+  * Sending prompts (`POST /query`).
+  * Resetting history (`DELETE /history/:modelId`).
+
+All endpoints require the user to have the access token generated for the model.
+
+## Frontend Overview
+
+* `AiAssistantProvider` handles fetching models/history, sending prompts, and exposing chat state via `useAiAssistant`.
+* `AiAssistantToggle` renders the sparkles button in the header and the chat dialog. The button displays a spinner while a request is in flight and disables itself if no models are accessible.
+* Conversation history is stored client-side for rendering while the server keeps the authoritative in-memory copy.
+
+## Extending With New Models
+
+To register a new model:
+
+1. Create a class that extends `AbstractAiModelService` and implement `generateReply`.
+2. Add a factory entry to `modelFactories` in `bindAiAssistant.ts`.
+3. Reference the new model identifier in `aiAssistant.models` within your configuration.
+4. Assign the generated access token (`ai-assistant-<modelId>`) to the user groups that should have access.

--- a/fixture/adminizerConfig.ts
+++ b/fixture/adminizerConfig.ts
@@ -435,6 +435,11 @@ const config: AdminpanelConfig = {
     notifications: {
         enabled: true
     },
+    aiAssistant: {
+        enabled: true,
+        defaultModel: 'dummy',
+        models: ['dummy']
+    },
     routePrefix: routePrefix,
     // routePrefix: "/admin",
     auth: {

--- a/fixture/helpers/seedDatabase.ts
+++ b/fixture/helpers/seedDatabase.ts
@@ -39,8 +39,9 @@ export async function seedDatabase(
          "read-example-model",
          "update-example-model",
         
-         "read-jsonschema-model",
-        ] 
+        "read-jsonschema-model",
+        "ai-assistant-dummy",
+        ]
       },
     { name: 'Guests', description: 'Guest access' },
   ];

--- a/src/assets/js/components/ai-assistant/AiAssistantToggle.tsx
+++ b/src/assets/js/components/ai-assistant/AiAssistantToggle.tsx
@@ -1,0 +1,151 @@
+import {FormEvent, useState} from 'react';
+import {Sparkles, LoaderCircle} from 'lucide-react';
+import {Button} from '@/components/ui/button';
+import {Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle} from '@/components/ui/dialog';
+import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from '@/components/ui/select';
+import {Textarea} from '@/components/ui/textarea';
+import {Tooltip, TooltipContent, TooltipTrigger} from '@/components/ui/tooltip';
+import {useAiAssistant} from '@/contexts/AiAssistantContext';
+import clsx from 'clsx';
+
+export function AiAssistantToggle() {
+    const {
+        isEnabled,
+        isOpen,
+        toggleChat,
+        openChat,
+        closeChat,
+        models,
+        activeModel,
+        setActiveModel,
+        messages,
+        loading,
+        sending,
+        error,
+        sendMessage,
+    } = useAiAssistant();
+    const [input, setInput] = useState('');
+
+    if (!isEnabled) {
+        return null;
+    }
+
+    const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        await sendMessage(input);
+        setInput('');
+    };
+
+    const hasModels = models.length > 0;
+
+    return (
+        <>
+            <Tooltip>
+                <TooltipTrigger asChild>
+                    <Button
+                        variant="ghost"
+                        className={clsx('relative', {'text-primary': isOpen})}
+                        onClick={toggleChat}
+                        disabled={!hasModels && loading}
+                    >
+                        {sending ? <LoaderCircle className="size-4 animate-spin"/> : <Sparkles className="size-4"/>}
+                    </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" className="z-[1002]">
+                    <span>AI assistant</span>
+                </TooltipContent>
+            </Tooltip>
+
+            <Dialog open={isOpen} onOpenChange={(open) => (open ? openChat() : closeChat())}>
+                <DialogContent className="max-w-2xl">
+                    <DialogHeader className="gap-4 text-left">
+                        <DialogTitle className="flex items-center gap-2">
+                            <Sparkles className="size-5 text-primary"/>
+                            AI assistant
+                        </DialogTitle>
+                        <DialogDescription>
+                            Chat with the AI assistant and pick a model to process your request.
+                        </DialogDescription>
+                    </DialogHeader>
+
+                    {!hasModels && !loading && (
+                        <div className="rounded-md border border-dashed p-6 text-sm text-muted-foreground">
+                            No AI models are available for your account.
+                        </div>
+                    )}
+
+                    {hasModels && (
+                        <div className="flex flex-col gap-4">
+                            <Select value={activeModel} onValueChange={setActiveModel}>
+                                <SelectTrigger className="w-full">
+                                    <SelectValue placeholder="Select a model"/>
+                                </SelectTrigger>
+                                <SelectContent className="z-[1003]">
+                                    {models.map((model) => (
+                                        <SelectItem key={model.id} value={model.id}>
+                                            <div className="flex flex-col text-left">
+                                                <span className="font-medium">{model.name}</span>
+                                                {model.description && (
+                                                    <span className="text-xs text-muted-foreground">{model.description}</span>
+                                                )}
+                                            </div>
+                                        </SelectItem>
+                                    ))}
+                                </SelectContent>
+                            </Select>
+
+                            <div className="flex h-72 flex-col gap-3 overflow-hidden rounded-md border p-4">
+                                <div className="flex-1 space-y-3 overflow-y-auto pr-2">
+                                    {loading && (
+                                        <div className="flex justify-center py-6 text-sm text-muted-foreground">
+                                            Loading conversation...
+                                        </div>
+                                    )}
+                                    {!loading && messages.length === 0 && (
+                                        <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+                                            Start a conversation to see responses here.
+                                        </div>
+                                    )}
+                                    {messages.map((message) => (
+                                        <div
+                                            key={message.id}
+                                            className={clsx(
+                                                'flex flex-col gap-1 rounded-md border p-3 text-sm shadow-xs',
+                                                message.role === 'assistant'
+                                                    ? 'border-primary/30 bg-primary/5'
+                                                    : 'border-border bg-background'
+                                            )}
+                                        >
+                                            <span className="font-semibold">
+                                                {message.role === 'assistant' ? 'Assistant' : 'You'}
+                                            </span>
+                                            <p className="whitespace-pre-wrap leading-relaxed">{message.content}</p>
+                                            <span className="text-xs text-muted-foreground">
+                                                {new Date(message.timestamp).toLocaleTimeString()}
+                                            </span>
+                                        </div>
+                                    ))}
+                                </div>
+                                <form className="space-y-2" onSubmit={handleSubmit}>
+                                    <Textarea
+                                        placeholder={hasModels ? 'Type your question...' : 'No models available'}
+                                        value={input}
+                                        onChange={(event) => setInput(event.target.value)}
+                                        disabled={!hasModels || sending}
+                                        rows={3}
+                                    />
+                                    <div className="flex items-center justify-between gap-3">
+                                        {error && <span className="text-xs text-destructive">{error}</span>}
+                                        <Button type="submit" disabled={!hasModels || sending || !input.trim()}>
+                                            {sending ? 'Sending…' : 'Send'}
+                                        </Button>
+                                    </div>
+                                </form>
+                            </div>
+                        </div>
+                    )}
+                </DialogContent>
+            </Dialog>
+        </>
+    );
+}

--- a/src/assets/js/components/app-sidebar-header.tsx
+++ b/src/assets/js/components/app-sidebar-header.tsx
@@ -4,6 +4,7 @@ import {type BreadcrumbItem as BreadcrumbItemType, SharedData} from '@/types';
 import {NavUser} from "@/components/nav-user.tsx";
 import ThemeSwitcher from '@/components/theme-switcher';
 import {NotificationCenter} from "@/components/notifications/NotificationCenter.tsx";
+import {AiAssistantToggle} from '@/components/ai-assistant/AiAssistantToggle';
 import {useNotifications} from "@/contexts/NotificationContext.tsx";
 import {LoaderCircle} from "lucide-react";
 import {usePage} from "@inertiajs/react";
@@ -20,6 +21,7 @@ export function AppSidebarHeader({breadcrumbs = []}: { breadcrumbs?: BreadcrumbI
                     <Breadcrumbs breadcrumbs={breadcrumbs}/>
                 </div>
                 <div className="flex gap-4 items-center">
+                    <AiAssistantToggle/>
                     <ThemeSwitcher/>
                     {page.props.notifications && (
                         tabs.length > 0 ?

--- a/src/assets/js/contexts/AiAssistantContext.tsx
+++ b/src/assets/js/contexts/AiAssistantContext.tsx
@@ -1,0 +1,193 @@
+import {createContext, useCallback, useContext, useEffect, useMemo, useState} from 'react';
+import axios from 'axios';
+import {usePage} from '@inertiajs/react';
+import {SharedData} from '@/types';
+
+export interface AiAssistantMessageDto {
+    id: string;
+    role: 'user' | 'assistant';
+    content: string;
+    timestamp: string;
+    modelId: string;
+}
+
+export interface AiAssistantModelDto {
+    id: string;
+    name: string;
+    description?: string;
+}
+
+interface AiAssistantContextValue {
+    isEnabled: boolean;
+    isOpen: boolean;
+    openChat: () => void;
+    closeChat: () => void;
+    toggleChat: () => void;
+    models: AiAssistantModelDto[];
+    activeModel?: string;
+    setActiveModel: (modelId: string) => void;
+    messages: AiAssistantMessageDto[];
+    loading: boolean;
+    sending: boolean;
+    error?: string | null;
+    sendMessage: (message: string) => Promise<void>;
+    refreshHistory: () => Promise<void>;
+}
+
+const AiAssistantContext = createContext<AiAssistantContextValue | undefined>(undefined);
+
+export const AiAssistantProvider: React.FC<{children: React.ReactNode}> = ({children}) => {
+    const page = usePage<SharedData>();
+    const aiAssistantConfig = page.props.aiAssistant;
+    const [isOpen, setIsOpen] = useState(false);
+    const [models, setModels] = useState<AiAssistantModelDto[]>([]);
+    const [activeModel, setActiveModelState] = useState<string | undefined>(aiAssistantConfig?.defaultModel ?? undefined);
+    const [messages, setMessages] = useState<AiAssistantMessageDto[]>([]);
+    const [loading, setLoading] = useState(false);
+    const [sending, setSending] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const isEnabled = aiAssistantConfig?.enabled ?? false;
+
+    const fetchModels = useCallback(async () => {
+        if (!isEnabled) return;
+        try {
+            setLoading(true);
+            const {data} = await axios.get<AiAssistantModelDto[]>(`${window.routePrefix}/api/ai-assistant/models`);
+            setModels(data);
+            setActiveModelState((current) => {
+                if (current) {
+                    return current;
+                }
+                const defaultCandidate = aiAssistantConfig?.defaultModel && data.some((model) => model.id === aiAssistantConfig.defaultModel)
+                    ? aiAssistantConfig.defaultModel
+                    : data[0]?.id;
+                return defaultCandidate;
+            });
+        } catch (err) {
+            console.error('Failed to load AI assistant models', err);
+            setError('Unable to load AI assistant models');
+        } finally {
+            setLoading(false);
+        }
+    }, [aiAssistantConfig?.defaultModel, isEnabled]);
+
+    const fetchHistory = useCallback(async (modelId: string) => {
+        if (!isEnabled || !modelId) return;
+        try {
+            setLoading(true);
+            const {data} = await axios.get<{history: AiAssistantMessageDto[]}>(`${window.routePrefix}/api/ai-assistant/history/${modelId}`);
+            setMessages(data.history ?? []);
+        } catch (err) {
+            console.error('Failed to load AI assistant history', err);
+            setError('Unable to load AI assistant history');
+        } finally {
+            setLoading(false);
+        }
+    }, [isEnabled]);
+
+    useEffect(() => {
+        if (!isEnabled) {
+            setMessages([]);
+            return;
+        }
+        void fetchModels();
+    }, [fetchModels, isEnabled]);
+
+    useEffect(() => {
+        if (!isEnabled || !activeModel) return;
+        void fetchHistory(activeModel);
+    }, [activeModel, fetchHistory, isEnabled]);
+
+    const setActiveModel = useCallback((modelId: string) => {
+        setActiveModelState(modelId);
+    }, []);
+
+    const openChat = useCallback(() => setIsOpen(true), []);
+    const closeChat = useCallback(() => setIsOpen(false), []);
+    const toggleChat = useCallback(() => setIsOpen((prev) => !prev), []);
+
+    const sendMessage = useCallback(async (message: string) => {
+        if (!isEnabled || !activeModel) return;
+        const trimmed = message.trim();
+        if (!trimmed) return;
+
+        const optimisticMessage: AiAssistantMessageDto = {
+            id: `tmp-${Date.now()}`,
+            role: 'user',
+            content: trimmed,
+            timestamp: new Date().toISOString(),
+            modelId: activeModel,
+        };
+
+        setMessages((prev) => [...prev, optimisticMessage]);
+        setSending(true);
+        setError(null);
+
+        try {
+            const {data} = await axios.post<{history: AiAssistantMessageDto[]; modelId: string}>(
+                `${window.routePrefix}/api/ai-assistant/query`,
+                {modelId: activeModel, message: trimmed},
+            );
+            setMessages(data.history ?? []);
+        } catch (err) {
+            console.error('Failed to send AI assistant message', err);
+            setError('Unable to reach AI assistant');
+            await fetchHistory(activeModel);
+        } finally {
+            setSending(false);
+        }
+    }, [activeModel, fetchHistory, isEnabled]);
+
+    const refreshHistory = useCallback(async () => {
+        if (activeModel) {
+            await fetchHistory(activeModel);
+        }
+    }, [activeModel, fetchHistory]);
+
+    const value = useMemo<AiAssistantContextValue>(() => ({
+        isEnabled,
+        isOpen,
+        openChat,
+        closeChat,
+        toggleChat,
+        models,
+        activeModel,
+        setActiveModel,
+        messages,
+        loading,
+        sending,
+        error,
+        sendMessage,
+        refreshHistory,
+    }), [
+        activeModel,
+        closeChat,
+        error,
+        isEnabled,
+        isOpen,
+        loading,
+        messages,
+        models,
+        openChat,
+        refreshHistory,
+        sendMessage,
+        sending,
+        setActiveModel,
+        toggleChat,
+    ]);
+
+    return (
+        <AiAssistantContext.Provider value={value}>
+            {children}
+        </AiAssistantContext.Provider>
+    );
+};
+
+export const useAiAssistant = (): AiAssistantContextValue => {
+    const context = useContext(AiAssistantContext);
+    if (!context) {
+        throw new Error('useAiAssistant must be used within an AiAssistantProvider');
+    }
+    return context;
+};

--- a/src/assets/js/layouts/app-layout.tsx
+++ b/src/assets/js/layouts/app-layout.tsx
@@ -2,6 +2,7 @@ import AppLayoutTemplate from '@/layouts/app/app-sidebar-layout';
 import {type BreadcrumbItem} from '@/types';
 import {memo, type ReactNode} from 'react';
 import {NotificationProvider} from '@/contexts/NotificationContext';
+import {AiAssistantProvider} from '@/contexts/AiAssistantContext';
 
 interface AppLayoutProps {
     children: ReactNode;
@@ -12,9 +13,11 @@ interface AppLayoutProps {
 const AppLayout = memo(({children, className, breadcrumbs, ...props}: AppLayoutProps) => {
     return (
         <NotificationProvider>
-            <AppLayoutTemplate breadcrumbs={breadcrumbs} className={className} {...props}>
-                {children}
-            </AppLayoutTemplate>
+            <AiAssistantProvider>
+                <AppLayoutTemplate breadcrumbs={breadcrumbs} className={className} {...props}>
+                    {children}
+                </AppLayoutTemplate>
+            </AiAssistantProvider>
         </NotificationProvider>
     )
 });

--- a/src/assets/js/types/index.d.ts
+++ b/src/assets/js/types/index.d.ts
@@ -42,6 +42,10 @@ export interface SharedData {
     flash: Record<FlashMessages, string>;
     auth: Auth;
     notifications: boolean;
+    aiAssistant?: {
+        enabled: boolean;
+        defaultModel: string | null;
+    };
     [key: string]: unknown;
 }
 

--- a/src/controllers/ai/AiAssistantController.ts
+++ b/src/controllers/ai/AiAssistantController.ts
@@ -1,0 +1,116 @@
+import {Adminizer} from '../../lib/Adminizer';
+import {AiAssistantMessage} from '../../interfaces/types';
+
+export class AiAssistantController {
+    static async getModels(req: ReqType, res: ResType) {
+        if (!req.adminizer.config.aiAssistant?.enabled) {
+            return res.json([]);
+        }
+
+        const handler = req.adminizer.aiAssistantHandler;
+        if (!handler) {
+            Adminizer.log.warn('AI assistant handler is not initialized');
+            return res.json([]);
+        }
+
+        const models = handler
+            .getModels()
+            .filter((model) =>
+                req.adminizer.accessRightsHelper.hasPermission(`ai-assistant-${model.id}`, req.user),
+            );
+
+        res.json(models);
+    }
+
+    static async getHistory(req: ReqType, res: ResType) {
+        if (!req.adminizer.config.aiAssistant?.enabled) {
+            return res.json({history: []});
+        }
+
+        const {modelId} = req.params;
+        if (!modelId) {
+            return res.status(400).json({error: 'Model id is required'});
+        }
+
+        if (!req.adminizer.accessRightsHelper.hasPermission(`ai-assistant-${modelId}`, req.user)) {
+            return res.status(403).json({error: 'Forbidden'});
+        }
+
+        const handler = req.adminizer.aiAssistantHandler;
+        if (!handler) {
+            return res.status(500).json({error: 'AI assistant is not available'});
+        }
+
+        const history = handler.getHistory(req.user.id, modelId).map(AiAssistantController.serializeMessage);
+        res.json({history});
+    }
+
+    static async sendMessage(req: ReqType, res: ResType) {
+        if (!req.adminizer.config.aiAssistant?.enabled) {
+            return res.status(503).json({error: 'AI assistant is disabled'});
+        }
+
+        const {modelId, message} = req.body as {modelId?: string; message?: string};
+
+        if (!modelId || typeof modelId !== 'string') {
+            return res.status(400).json({error: 'Model id is required'});
+        }
+
+        if (!message || typeof message !== 'string' || message.trim().length === 0) {
+            return res.status(400).json({error: 'Message is required'});
+        }
+
+        if (!req.adminizer.accessRightsHelper.hasPermission(`ai-assistant-${modelId}`, req.user)) {
+            return res.status(403).json({error: 'Forbidden'});
+        }
+
+        const handler = req.adminizer.aiAssistantHandler;
+        if (!handler) {
+            return res.status(500).json({error: 'AI assistant is not available'});
+        }
+
+        try {
+            const response = await handler.sendMessage(req.user, modelId, message.trim());
+            res.json({
+                modelId,
+                history: response.history.map(AiAssistantController.serializeMessage),
+            });
+        } catch (error) {
+            Adminizer.log.error('AI assistant error', error);
+            res.status(500).json({error: 'Failed to process request'});
+        }
+    }
+
+    static async resetHistory(req: ReqType, res: ResType) {
+        if (!req.adminizer.config.aiAssistant?.enabled) {
+            return res.status(503).json({error: 'AI assistant is disabled'});
+        }
+
+        const {modelId} = req.params;
+        if (!modelId) {
+            return res.status(400).json({error: 'Model id is required'});
+        }
+
+        if (!req.adminizer.accessRightsHelper.hasPermission(`ai-assistant-${modelId}`, req.user)) {
+            return res.status(403).json({error: 'Forbidden'});
+        }
+
+        const handler = req.adminizer.aiAssistantHandler;
+        if (!handler) {
+            return res.status(500).json({error: 'AI assistant is not available'});
+        }
+
+        handler.resetHistory(req.user.id, modelId);
+        res.json({history: []});
+    }
+
+    private static serializeMessage(message: AiAssistantMessage) {
+        return {
+            id: message.id,
+            role: message.role,
+            content: message.content,
+            timestamp: message.timestamp instanceof Date ? message.timestamp.toISOString() : message.timestamp,
+            modelId: message.modelId,
+        };
+    }
+}

--- a/src/controllers/ai/AiAssistantController.ts
+++ b/src/controllers/ai/AiAssistantController.ts
@@ -19,7 +19,7 @@ export class AiAssistantController {
                 req.adminizer.accessRightsHelper.hasPermission(`ai-assistant-${model.id}`, req.user),
             );
 
-        res.json(models);
+        return res.json(models);
     }
 
     static async getHistory(req: ReqType, res: ResType) {
@@ -42,7 +42,7 @@ export class AiAssistantController {
         }
 
         const history = handler.getHistory(req.user.id, modelId).map(AiAssistantController.serializeMessage);
-        res.json({history});
+        return res.json({history});
     }
 
     static async sendMessage(req: ReqType, res: ResType) {
@@ -71,13 +71,13 @@ export class AiAssistantController {
 
         try {
             const response = await handler.sendMessage(req.user, modelId, message.trim());
-            res.json({
+            return res.json({
                 modelId,
                 history: response.history.map(AiAssistantController.serializeMessage),
             });
         } catch (error) {
             Adminizer.log.error('AI assistant error', error);
-            res.status(500).json({error: 'Failed to process request'});
+            return res.status(500).json({error: 'Failed to process request'});
         }
     }
 
@@ -101,7 +101,7 @@ export class AiAssistantController {
         }
 
         handler.resetHistory(req.user.id, modelId);
-        res.json({history: []});
+        return res.json({history: []});
     }
 
     private static serializeMessage(message: AiAssistantMessage) {

--- a/src/interfaces/adminpanelConfig.ts
+++ b/src/interfaces/adminpanelConfig.ts
@@ -254,6 +254,11 @@ export interface AdminpanelConfig {
     notifications?: {
         enabled: boolean
     }
+    aiAssistant?: {
+        enabled: boolean
+        defaultModel?: string
+        models?: string[]
+    }
 }
 
 export interface ModelConfig {

--- a/src/interfaces/types.ts
+++ b/src/interfaces/types.ts
@@ -71,6 +71,22 @@ export interface INotificationEvent {
     userId?: number;
 }
 
+export type AiAssistantRole = 'user' | 'assistant';
+
+export interface AiAssistantMessage {
+    id: string;
+    role: AiAssistantRole;
+    content: string;
+    timestamp: Date;
+    modelId: string;
+}
+
+export interface AiAssistantModelInfo {
+    id: string;
+    name: string;
+    description?: string;
+}
+
 export type Migration = {
   name: string;
   timestamp: number,

--- a/src/lib/Adminizer.ts
+++ b/src/lib/Adminizer.ts
@@ -34,9 +34,10 @@ import {ControlsHandler} from "./controls/ControlsHandler";
 import {CatalogHandler} from "./catalog/CatalogHandler";
 import {v4 as uuid} from "uuid";
 import { NotificationHandler } from './notifications/NotificationHandler';
-import { GeneralNotificationService } from './notifications/GeneralNotificationService';
 import { SystemNotificationService } from './notifications/SystemNotificationService';
+import { AiAssistantHandler } from './ai-assistant/AiAssistantHandler';
 import {bindNotifications} from "../system/bindNotifications";
+import {bindAiAssistant} from "../system/bindAiAssistant";
 import {INotification} from "../interfaces/types";
 
 export class Adminizer {
@@ -57,6 +58,7 @@ export class Adminizer {
     configHelper: ConfigHelper
     menuHelper: MenuHelper
     notificationHandler!: NotificationHandler;
+    aiAssistantHandler!: AiAssistantHandler;
     modelHandler!: ModelHandler
     widgetHandler: WidgetHandler
     vite: ViteDevServer
@@ -282,6 +284,8 @@ export class Adminizer {
 
         // Bind notifications
         if (this.config.notifications.enabled) await bindNotifications(this);
+
+        if (this.config.aiAssistant?.enabled) await bindAiAssistant(this);
 
         await Router.bind(this); // must be after binding policies and req/res functions
 

--- a/src/lib/ai-assistant/AbstractAiModelService.ts
+++ b/src/lib/ai-assistant/AbstractAiModelService.ts
@@ -1,0 +1,42 @@
+import {Adminizer} from '../Adminizer';
+import {AiAssistantMessage, AiAssistantModelInfo} from '../../interfaces/types';
+import {UserAP} from '../../models/UserAP';
+
+/**
+ * Base class for AI assistant models. It is responsible for registering
+ * access rights for the model and providing metadata for the front-end.
+ */
+export abstract class AbstractAiModelService {
+    protected readonly adminizer: Adminizer;
+    public abstract readonly id: string;
+    public abstract readonly name: string;
+    public abstract readonly description?: string;
+
+    protected constructor(adminizer: Adminizer) {
+        this.adminizer = adminizer;
+        this.registerAccessRight();
+    }
+
+    protected registerAccessRight(): void {
+        this.adminizer.accessRightsHelper.registerToken({
+            id: `ai-assistant-${this.id}`,
+            name: this.name,
+            description: `Access to AI assistant model ${this.name}`,
+            department: 'AI Assistant',
+        });
+    }
+
+    public getMetadata(): AiAssistantModelInfo {
+        return {
+            id: this.id,
+            name: this.name,
+            description: this.description,
+        };
+    }
+
+    public abstract generateReply(
+        prompt: string,
+        history: AiAssistantMessage[],
+        user: UserAP,
+    ): Promise<string>;
+}

--- a/src/lib/ai-assistant/AbstractAiModelService.ts
+++ b/src/lib/ai-assistant/AbstractAiModelService.ts
@@ -14,6 +14,9 @@ export abstract class AbstractAiModelService {
 
     protected constructor(adminizer: Adminizer) {
         this.adminizer = adminizer;
+    }
+
+    public initialize(): void {
         this.registerAccessRight();
     }
 

--- a/src/lib/ai-assistant/AiAssistantHandler.ts
+++ b/src/lib/ai-assistant/AiAssistantHandler.ts
@@ -1,0 +1,79 @@
+import {v4 as uuid} from 'uuid';
+import {Adminizer} from '../Adminizer';
+import {AbstractAiModelService} from './AbstractAiModelService';
+import {AiAssistantMessage, AiAssistantModelInfo} from '../../interfaces/types';
+import {UserAP} from '../../models/UserAP';
+
+export class AiAssistantHandler {
+    private readonly models = new Map<string, AbstractAiModelService>();
+    private readonly history = new Map<string, AiAssistantMessage[]>();
+
+    constructor(private readonly adminizer: Adminizer) {}
+
+    registerModel(service: AbstractAiModelService): void {
+        if (this.models.has(service.id)) {
+            Adminizer.log.warn(
+                `AI assistant model with id "${service.id}" is already registered. Overwriting.`,
+            );
+        }
+        this.models.set(service.id, service);
+    }
+
+    getModel(id: string): AbstractAiModelService | undefined {
+        return this.models.get(id);
+    }
+
+    getModels(): AiAssistantModelInfo[] {
+        return Array.from(this.models.values()).map((service) => service.getMetadata());
+    }
+
+    getHistory(userId: number, modelId: string): AiAssistantMessage[] {
+        return this.history.get(this.getSessionKey(userId, modelId)) ?? [];
+    }
+
+    resetHistory(userId: number, modelId: string): void {
+        this.history.delete(this.getSessionKey(userId, modelId));
+    }
+
+    async sendMessage(
+        user: UserAP,
+        modelId: string,
+        prompt: string,
+    ): Promise<{history: AiAssistantMessage[]}> {
+        const service = this.getModel(modelId);
+        if (!service) {
+            throw new Error(`AI assistant model not found: ${modelId}`);
+        }
+
+        const sessionKey = this.getSessionKey(user.id, modelId);
+        const currentHistory = [...this.getHistory(user.id, modelId)];
+
+        const userMessage: AiAssistantMessage = {
+            id: uuid(),
+            role: 'user',
+            content: prompt,
+            timestamp: new Date(),
+            modelId,
+        };
+        currentHistory.push(userMessage);
+
+        const reply = await service.generateReply(prompt, currentHistory, user);
+
+        const assistantMessage: AiAssistantMessage = {
+            id: uuid(),
+            role: 'assistant',
+            content: reply,
+            timestamp: new Date(),
+            modelId,
+        };
+
+        currentHistory.push(assistantMessage);
+        this.history.set(sessionKey, currentHistory);
+
+        return {history: currentHistory};
+    }
+
+    private getSessionKey(userId: number, modelId: string): string {
+        return `${userId}:${modelId}`;
+    }
+}

--- a/src/lib/ai-assistant/AiAssistantHandler.ts
+++ b/src/lib/ai-assistant/AiAssistantHandler.ts
@@ -16,6 +16,7 @@ export class AiAssistantHandler {
                 `AI assistant model with id "${service.id}" is already registered. Overwriting.`,
             );
         }
+        service.initialize();
         this.models.set(service.id, service);
     }
 

--- a/src/lib/ai-assistant/DummyAiModelService.ts
+++ b/src/lib/ai-assistant/DummyAiModelService.ts
@@ -1,6 +1,7 @@
 import {AbstractAiModelService} from './AbstractAiModelService';
 import {AiAssistantMessage} from '../../interfaces/types';
 import {UserAP} from '../../models/UserAP';
+import {Adminizer} from '../Adminizer';
 
 const DUMMY_RESPONSE = 'Ai-assystant dummy in deveploment';
 
@@ -8,6 +9,10 @@ export class DummyAiModelService extends AbstractAiModelService {
     public readonly id = 'dummy';
     public readonly name = 'Dummy assistant';
     public readonly description = 'Development placeholder model that returns a static response.';
+
+    public constructor(adminizer: Adminizer) {
+        super(adminizer);
+    }
 
     public async generateReply(
         _prompt: string,

--- a/src/lib/ai-assistant/DummyAiModelService.ts
+++ b/src/lib/ai-assistant/DummyAiModelService.ts
@@ -1,0 +1,19 @@
+import {AbstractAiModelService} from './AbstractAiModelService';
+import {AiAssistantMessage} from '../../interfaces/types';
+import {UserAP} from '../../models/UserAP';
+
+const DUMMY_RESPONSE = 'Ai-assystant dummy in deveploment';
+
+export class DummyAiModelService extends AbstractAiModelService {
+    public readonly id = 'dummy';
+    public readonly name = 'Dummy assistant';
+    public readonly description = 'Development placeholder model that returns a static response.';
+
+    public async generateReply(
+        _prompt: string,
+        _history: AiAssistantMessage[],
+        _user: UserAP,
+    ): Promise<string> {
+        return DUMMY_RESPONSE;
+    }
+}

--- a/src/system/Router.ts
+++ b/src/system/Router.ts
@@ -20,6 +20,7 @@ import {thumbController} from "../controllers/media-manager/ThumbController";
 import {Adminizer} from "../lib/Adminizer";
 import timezones from "../controllers/timezones";
 import {NotificationController} from "../controllers/notifications/NotificationController";
+import {AiAssistantController} from "../controllers/ai/AiAssistantController";
 
 export default class Router {
 
@@ -158,6 +159,28 @@ export default class Router {
                 adminizer.policyManager.bindPolicies(policies, NotificationController.search)
             );
         }
+        if (adminizer.config.aiAssistant?.enabled) {
+            adminizer.app.get(
+                `${adminizer.config.routePrefix}/api/ai-assistant/models`,
+                adminizer.policyManager.bindPolicies(policies, AiAssistantController.getModels)
+            );
+
+            adminizer.app.get(
+                `${adminizer.config.routePrefix}/api/ai-assistant/history/:modelId`,
+                adminizer.policyManager.bindPolicies(policies, AiAssistantController.getHistory)
+            );
+
+            adminizer.app.post(
+                `${adminizer.config.routePrefix}/api/ai-assistant/query`,
+                adminizer.policyManager.bindPolicies(policies, AiAssistantController.sendMessage)
+            );
+
+            adminizer.app.delete(
+                `${adminizer.config.routePrefix}/api/ai-assistant/history/:modelId`,
+                adminizer.policyManager.bindPolicies(policies, AiAssistantController.resetHistory)
+            );
+        }
+
         /**
          * List of records
          */

--- a/src/system/bindAiAssistant.ts
+++ b/src/system/bindAiAssistant.ts
@@ -1,0 +1,32 @@
+import {Adminizer} from '../lib/Adminizer';
+import {AiAssistantHandler} from '../lib/ai-assistant/AiAssistantHandler';
+import {DummyAiModelService} from '../lib/ai-assistant/DummyAiModelService';
+import {AbstractAiModelService} from '../lib/ai-assistant/AbstractAiModelService';
+
+const modelFactories: Record<string, (adminizer: Adminizer) => AbstractAiModelService> = {
+    dummy: (adminizer) => new DummyAiModelService(adminizer),
+};
+
+export async function bindAiAssistant(adminizer: Adminizer): Promise<void> {
+    adminizer.aiAssistantHandler = new AiAssistantHandler(adminizer);
+
+    const configModels = adminizer.config.aiAssistant?.models;
+    const requestedModels = Array.isArray(configModels) && configModels.length > 0
+        ? configModels
+        : ['dummy'];
+
+    requestedModels.forEach((modelId) => {
+        const factory = modelFactories[modelId];
+        if (!factory) {
+            Adminizer.log.warn(`AI assistant model "${modelId}" is not registered. Skipping.`);
+            return;
+        }
+
+        const service = factory(adminizer);
+        adminizer.aiAssistantHandler.registerModel(service);
+    });
+
+    Adminizer.log.info(
+        `AI assistant initialized with models: ${adminizer.aiAssistantHandler.getModels().map((m) => m.id).join(', ')}`,
+    );
+}

--- a/src/system/bindInertia.ts
+++ b/src/system/bindInertia.ts
@@ -155,6 +155,10 @@ export function bindInertia(adminizer: Adminizer) {
             ] : null,
             showVersion: req.adminizer.config.showVersion ?? false,
             notifications: req.adminizer.config.notifications.enabled ?? false,
+            aiAssistant: {
+                enabled: req.adminizer.config.aiAssistant?.enabled ?? false,
+                defaultModel: req.adminizer.config.aiAssistant?.defaultModel ?? null,
+            },
         });
 
         next();

--- a/src/system/defaults.ts
+++ b/src/system/defaults.ts
@@ -154,6 +154,11 @@ let adminpanelConfig: AdminpanelConfig = {
     },
     notifications: {
         enabled: false
+    },
+    aiAssistant: {
+        enabled: false,
+        defaultModel: 'dummy',
+        models: ['dummy']
     }
 }
 


### PR DESCRIPTION
## Summary
- add AI assistant backend scaffolding with handler, binder, routes, and configuration defaults
- create frontend provider and header toggle that opens the AI assistant chat with model selection
- document the feature and log the change in the project history

## Testing
- npm test *(fails: vitest executable unavailable before dependency install)*
- npm run build *(fails: missing dev dependencies such as shelljs because npm install cannot resolve peer conflicts)*

------
https://chatgpt.com/codex/tasks/task_e_68d638d91724832aa31698319ff16648