### PR TITLE
Dock AI assistant chat panel

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,15 @@
+## 4.3.4
+- Replaced the AI assistant dialog with a docked panel that slides in from the right and shifts the application layout by a quarter width.
+- Added documentation detailing the docked chat experience and supporting components.
+
+## 4.3.3
+- Enabled the AI assistant in the fixture configuration with the dummy model and ensured the backend build wires controller en
+dpoints.
+- Documented that the fixture ships with the in-memory assistant for local testing.
+
+## 4.3.2
+- Added AI assistant chat mode with header toggle, in-memory history, and backend API scaffolding.
+
 
 ## 4.2.1
 - Renamed MediaManager parent association to `parent` to resolve Sequelize naming collision.

--- a/docs/AiAssistant.md
+++ b/docs/AiAssistant.md
@@ -1,0 +1,53 @@
+# AI Assistant Integration
+
+The AI assistant feature introduces a chat experience that can be toggled from the main header. It is disabled by default and can be enabled through the admin panel configuration.
+
+## Configuration
+
+The `AdminpanelConfig` accepts an optional `aiAssistant` section:
+
+```ts
+aiAssistant?: {
+    enabled: boolean;
+    defaultModel?: string;
+    models?: string[];
+}
+```
+
+* `enabled` — toggles the feature on or off (defaults to `false`).
+* `defaultModel` — preferred model identifier that will be preselected on the client.
+* `models` — list of model identifiers to register. Unknown identifiers are ignored with a warning.
+
+The default configuration registers the in-memory `dummy` model that always replies with `Ai-assystant dummy in deveploment`.
+
+The fixture configuration enables the assistant with this dummy model so the chat can be exercised locally without any external
+dependencies.
+
+## Backend Overview
+
+* `AiAssistantHandler` keeps registered model services and in-memory conversation history per user and model.
+* Model services extend `AbstractAiModelService`, which automatically registers the corresponding access right (token pattern: `ai-assistant-<modelId>`).
+* The binder (`bindAiAssistant`) attaches the handler to `Adminizer` and registers models declared in the configuration.
+* `AiAssistantController` exposes REST endpoints under `/api/ai-assistant` for:
+  * Listing available models (`GET /models`).
+  * Fetching conversation history (`GET /history/:modelId`).
+  * Sending prompts (`POST /query`).
+  * Resetting history (`DELETE /history/:modelId`).
+
+All endpoints require the user to have the access token generated for the model.
+
+## Frontend Overview
+
+* `AiAssistantProvider` handles fetching models/history, sending prompts, and exposing chat state via `useAiAssistant`.
+* `AiAssistantToggle` renders the sparkles button in the header. When pressed, it opens a docked chat panel that occupies the rightmost quarter of the viewport.
+* `AiAssistantPanel` hosts the chat experience, including model selection, streaming conversation history, and the composer form. The main application content shifts left while the panel is visible so both areas remain accessible.
+* Conversation history is stored client-side for rendering while the server keeps the authoritative in-memory copy.
+
+## Extending With New Models
+
+To register a new model:
+
+1. Create a class that extends `AbstractAiModelService` and implement `generateReply`.
+2. Add a factory entry to `modelFactories` in `bindAiAssistant.ts`.
+3. Reference the new model identifier in `aiAssistant.models` within your configuration.
+4. Assign the generated access token (`ai-assistant-<modelId>`) to the user groups that should have access.

--- a/fixture/adminizerConfig.ts
+++ b/fixture/adminizerConfig.ts
@@ -435,6 +435,11 @@ const config: AdminpanelConfig = {
     notifications: {
         enabled: true
     },
+    aiAssistant: {
+        enabled: true,
+        defaultModel: 'dummy',
+        models: ['dummy'],
+    },
     routePrefix: routePrefix,
     // routePrefix: "/admin",
     auth: {

--- a/src/assets/js/components/ai-assistant/AiAssistantPanel.tsx
+++ b/src/assets/js/components/ai-assistant/AiAssistantPanel.tsx
@@ -1,0 +1,167 @@
+import {FormEvent, useEffect, useMemo, useRef, useState} from 'react';
+import {Sparkles, LoaderCircle, X} from 'lucide-react';
+import {Button} from '@/components/ui/button';
+import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from '@/components/ui/select';
+import {Textarea} from '@/components/ui/textarea';
+import {useAiAssistant} from '@/contexts/AiAssistantContext';
+import clsx from 'clsx';
+
+const PANEL_WIDTH = 'min(28rem, 25vw)';
+
+export function AiAssistantPanel() {
+    const {
+        isEnabled,
+        isOpen,
+        closeChat,
+        models,
+        activeModel,
+        setActiveModel,
+        messages,
+        loading,
+        sending,
+        error,
+        sendMessage,
+    } = useAiAssistant();
+    const [input, setInput] = useState('');
+    const scrollContainerRef = useRef<HTMLDivElement | null>(null);
+
+    useEffect(() => {
+        if (!isOpen) {
+            return;
+        }
+        const container = scrollContainerRef.current;
+        if (container) {
+            container.scrollTop = container.scrollHeight;
+        }
+    }, [messages, isOpen]);
+
+    useEffect(() => {
+        if (!isOpen) {
+            setInput('');
+        }
+    }, [isOpen]);
+
+    const hasModels = models.length > 0;
+    const helperText = useMemo(() => {
+        if (loading) {
+            return 'Loading conversation...';
+        }
+        if (!hasModels) {
+            return 'No AI models are available for your account.';
+        }
+        if (messages.length === 0) {
+            return 'Start a conversation to see responses here.';
+        }
+        return null;
+    }, [hasModels, loading, messages.length]);
+
+    if (!isEnabled) {
+        return null;
+    }
+
+    const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        await sendMessage(input);
+        setInput('');
+    };
+
+    return (
+        <div
+            aria-hidden={!isOpen}
+            className={clsx(
+                'absolute inset-y-0 right-0 z-[60] flex max-w-full transition-transform duration-300 ease-in-out',
+                isOpen ? 'translate-x-0' : 'pointer-events-none translate-x-full'
+            )}
+            style={{width: PANEL_WIDTH}}
+        >
+            <aside className="flex h-full w-full flex-col border-l bg-background shadow-2xl">
+                <header className="flex h-16 items-center justify-between border-b px-4">
+                    <div className="flex items-center gap-3">
+                        <span className="flex h-9 w-9 items-center justify-center rounded-full bg-primary/10">
+                            <Sparkles className="size-5 text-primary"/>
+                        </span>
+                        <div className="flex flex-col">
+                            <span className="text-sm font-semibold leading-tight">AI assistant</span>
+                            <span className="text-xs text-muted-foreground">Chat with the assistant and pick a model.</span>
+                        </div>
+                    </div>
+                    <Button variant="ghost" size="icon" onClick={closeChat} aria-label="Close AI assistant">
+                        <X className="size-4"/>
+                    </Button>
+                </header>
+
+                <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-hidden px-4 py-4">
+                    <Select value={activeModel} onValueChange={setActiveModel} disabled={!hasModels || loading}>
+                        <SelectTrigger className="w-full" aria-label="Select AI assistant model">
+                            <SelectValue placeholder={loading ? 'Loading models...' : 'Select a model'}/>
+                        </SelectTrigger>
+                        <SelectContent className="z-[1003]">
+                            {models.map((model) => (
+                                <SelectItem key={model.id} value={model.id}>
+                                    <div className="flex flex-col text-left">
+                                        <span className="font-medium">{model.name}</span>
+                                        {model.description && (
+                                            <span className="text-xs text-muted-foreground">{model.description}</span>
+                                        )}
+                                    </div>
+                                </SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
+
+                    <div className="flex flex-1 flex-col gap-3 overflow-hidden rounded-md border">
+                        <div className="flex-1 overflow-hidden">
+                            <div className="flex h-full flex-col">
+                                <div className="flex-1 space-y-3 overflow-y-auto px-4 py-3" ref={scrollContainerRef}>
+                                    {helperText && (
+                                        <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+                                            {loading && <LoaderCircle className="mr-2 size-4 animate-spin"/>}
+                                            <span>{helperText}</span>
+                                        </div>
+                                    )}
+                                    {!helperText &&
+                                        messages.map((message) => (
+                                            <div
+                                                key={message.id}
+                                                className={clsx(
+                                                    'flex flex-col gap-1 rounded-md border p-3 text-sm shadow-xs',
+                                                    message.role === 'assistant'
+                                                        ? 'border-primary/30 bg-primary/5'
+                                                        : 'border-border bg-background'
+                                                )}
+                                            >
+                                                <span className="font-semibold">
+                                                    {message.role === 'assistant' ? 'Assistant' : 'You'}
+                                                </span>
+                                                <p className="whitespace-pre-wrap leading-relaxed">{message.content}</p>
+                                                <span className="text-xs text-muted-foreground">
+                                                    {new Date(message.timestamp).toLocaleTimeString()}
+                                                </span>
+                                            </div>
+                                        ))}
+                                </div>
+                            </div>
+                        </div>
+                        <form className="space-y-2 border-t px-4 py-3" onSubmit={handleSubmit}>
+                            <Textarea
+                                placeholder={hasModels ? 'Type your question...' : 'No models available'}
+                                value={input}
+                                onChange={(event) => setInput(event.target.value)}
+                                disabled={!hasModels || sending}
+                                rows={3}
+                            />
+                            <div className="flex items-center justify-between gap-3">
+                                {error && <span className="text-xs text-destructive">{error}</span>}
+                                <Button type="submit" disabled={!hasModels || sending || !input.trim()}>
+                                    {sending ? 'Sending…' : 'Send'}
+                                </Button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </aside>
+        </div>
+    );
+}
+
+export const AI_ASSISTANT_PANEL_WIDTH = PANEL_WIDTH;

--- a/src/assets/js/components/ai-assistant/AiAssistantToggle.tsx
+++ b/src/assets/js/components/ai-assistant/AiAssistantToggle.tsx
@@ -1,0 +1,42 @@
+import {Sparkles, LoaderCircle} from 'lucide-react';
+import {Button} from '@/components/ui/button';
+import {Tooltip, TooltipContent, TooltipTrigger} from '@/components/ui/tooltip';
+import {useAiAssistant} from '@/contexts/AiAssistantContext';
+import clsx from 'clsx';
+
+export function AiAssistantToggle() {
+    const {
+        isEnabled,
+        isOpen,
+        toggleChat,
+        models,
+        loading,
+        sending,
+    } = useAiAssistant();
+
+    if (!isEnabled) {
+        return null;
+    }
+
+    const hasModels = models.length > 0;
+
+    return (
+        <>
+            <Tooltip>
+                <TooltipTrigger asChild>
+                    <Button
+                        variant="ghost"
+                        className={clsx('relative', {'text-primary': isOpen})}
+                        onClick={toggleChat}
+                        disabled={!hasModels && loading}
+                    >
+                        {sending ? <LoaderCircle className="size-4 animate-spin"/> : <Sparkles className="size-4"/>}
+                    </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" className="z-[1002]">
+                    <span>AI assistant</span>
+                </TooltipContent>
+            </Tooltip>
+        </>
+    );
+}

--- a/src/assets/js/components/app-sidebar-header.tsx
+++ b/src/assets/js/components/app-sidebar-header.tsx
@@ -4,6 +4,7 @@ import {type BreadcrumbItem as BreadcrumbItemType, SharedData} from '@/types';
 import {NavUser} from "@/components/nav-user.tsx";
 import ThemeSwitcher from '@/components/theme-switcher';
 import {NotificationCenter} from "@/components/notifications/NotificationCenter.tsx";
+import {AiAssistantToggle} from '@/components/ai-assistant/AiAssistantToggle';
 import {useNotifications} from "@/contexts/NotificationContext.tsx";
 import {LoaderCircle} from "lucide-react";
 import {usePage} from "@inertiajs/react";
@@ -20,6 +21,7 @@ export function AppSidebarHeader({breadcrumbs = []}: { breadcrumbs?: BreadcrumbI
                     <Breadcrumbs breadcrumbs={breadcrumbs}/>
                 </div>
                 <div className="flex gap-4 items-center">
+                    <AiAssistantToggle/>
                     <ThemeSwitcher/>
                     {page.props.notifications && (
                         tabs.length > 0 ?

--- a/src/assets/js/contexts/AiAssistantContext.tsx
+++ b/src/assets/js/contexts/AiAssistantContext.tsx
@@ -1,0 +1,193 @@
+import {createContext, useCallback, useContext, useEffect, useMemo, useState} from 'react';
+import axios from 'axios';
+import {usePage} from '@inertiajs/react';
+import {SharedData} from '@/types';
+
+export interface AiAssistantMessageDto {
+    id: string;
+    role: 'user' | 'assistant';
+    content: string;
+    timestamp: string;
+    modelId: string;
+}
+
+export interface AiAssistantModelDto {
+    id: string;
+    name: string;
+    description?: string;
+}
+
+interface AiAssistantContextValue {
+    isEnabled: boolean;
+    isOpen: boolean;
+    openChat: () => void;
+    closeChat: () => void;
+    toggleChat: () => void;
+    models: AiAssistantModelDto[];
+    activeModel?: string;
+    setActiveModel: (modelId: string) => void;
+    messages: AiAssistantMessageDto[];
+    loading: boolean;
+    sending: boolean;
+    error?: string | null;
+    sendMessage: (message: string) => Promise<void>;
+    refreshHistory: () => Promise<void>;
+}
+
+const AiAssistantContext = createContext<AiAssistantContextValue | undefined>(undefined);
+
+export const AiAssistantProvider: React.FC<{children: React.ReactNode}> = ({children}) => {
+    const page = usePage<SharedData>();
+    const aiAssistantConfig = page.props.aiAssistant;
+    const [isOpen, setIsOpen] = useState(false);
+    const [models, setModels] = useState<AiAssistantModelDto[]>([]);
+    const [activeModel, setActiveModelState] = useState<string | undefined>(aiAssistantConfig?.defaultModel ?? undefined);
+    const [messages, setMessages] = useState<AiAssistantMessageDto[]>([]);
+    const [loading, setLoading] = useState(false);
+    const [sending, setSending] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const isEnabled = aiAssistantConfig?.enabled ?? false;
+
+    const fetchModels = useCallback(async () => {
+        if (!isEnabled) return;
+        try {
+            setLoading(true);
+            const {data} = await axios.get<AiAssistantModelDto[]>(`${window.routePrefix}/api/ai-assistant/models`);
+            setModels(data);
+            setActiveModelState((current) => {
+                if (current) {
+                    return current;
+                }
+                const defaultCandidate = aiAssistantConfig?.defaultModel && data.some((model) => model.id === aiAssistantConfig.defaultModel)
+                    ? aiAssistantConfig.defaultModel
+                    : data[0]?.id;
+                return defaultCandidate;
+            });
+        } catch (err) {
+            console.error('Failed to load AI assistant models', err);
+            setError('Unable to load AI assistant models');
+        } finally {
+            setLoading(false);
+        }
+    }, [aiAssistantConfig?.defaultModel, isEnabled]);
+
+    const fetchHistory = useCallback(async (modelId: string) => {
+        if (!isEnabled || !modelId) return;
+        try {
+            setLoading(true);
+            const {data} = await axios.get<{history: AiAssistantMessageDto[]}>(`${window.routePrefix}/api/ai-assistant/history/${modelId}`);
+            setMessages(data.history ?? []);
+        } catch (err) {
+            console.error('Failed to load AI assistant history', err);
+            setError('Unable to load AI assistant history');
+        } finally {
+            setLoading(false);
+        }
+    }, [isEnabled]);
+
+    useEffect(() => {
+        if (!isEnabled) {
+            setMessages([]);
+            return;
+        }
+        void fetchModels();
+    }, [fetchModels, isEnabled]);
+
+    useEffect(() => {
+        if (!isEnabled || !activeModel) return;
+        void fetchHistory(activeModel);
+    }, [activeModel, fetchHistory, isEnabled]);
+
+    const setActiveModel = useCallback((modelId: string) => {
+        setActiveModelState(modelId);
+    }, []);
+
+    const openChat = useCallback(() => setIsOpen(true), []);
+    const closeChat = useCallback(() => setIsOpen(false), []);
+    const toggleChat = useCallback(() => setIsOpen((prev) => !prev), []);
+
+    const sendMessage = useCallback(async (message: string) => {
+        if (!isEnabled || !activeModel) return;
+        const trimmed = message.trim();
+        if (!trimmed) return;
+
+        const optimisticMessage: AiAssistantMessageDto = {
+            id: `tmp-${Date.now()}`,
+            role: 'user',
+            content: trimmed,
+            timestamp: new Date().toISOString(),
+            modelId: activeModel,
+        };
+
+        setMessages((prev) => [...prev, optimisticMessage]);
+        setSending(true);
+        setError(null);
+
+        try {
+            const {data} = await axios.post<{history: AiAssistantMessageDto[]; modelId: string}>(
+                `${window.routePrefix}/api/ai-assistant/query`,
+                {modelId: activeModel, message: trimmed},
+            );
+            setMessages(data.history ?? []);
+        } catch (err) {
+            console.error('Failed to send AI assistant message', err);
+            setError('Unable to reach AI assistant');
+            await fetchHistory(activeModel);
+        } finally {
+            setSending(false);
+        }
+    }, [activeModel, fetchHistory, isEnabled]);
+
+    const refreshHistory = useCallback(async () => {
+        if (activeModel) {
+            await fetchHistory(activeModel);
+        }
+    }, [activeModel, fetchHistory]);
+
+    const value = useMemo<AiAssistantContextValue>(() => ({
+        isEnabled,
+        isOpen,
+        openChat,
+        closeChat,
+        toggleChat,
+        models,
+        activeModel,
+        setActiveModel,
+        messages,
+        loading,
+        sending,
+        error,
+        sendMessage,
+        refreshHistory,
+    }), [
+        activeModel,
+        closeChat,
+        error,
+        isEnabled,
+        isOpen,
+        loading,
+        messages,
+        models,
+        openChat,
+        refreshHistory,
+        sendMessage,
+        sending,
+        setActiveModel,
+        toggleChat,
+    ]);
+
+    return (
+        <AiAssistantContext.Provider value={value}>
+            {children}
+        </AiAssistantContext.Provider>
+    );
+};
+
+export const useAiAssistant = (): AiAssistantContextValue => {
+    const context = useContext(AiAssistantContext);
+    if (!context) {
+        throw new Error('useAiAssistant must be used within an AiAssistantProvider');
+    }
+    return context;
+};

--- a/src/assets/js/layouts/app-layout.tsx
+++ b/src/assets/js/layouts/app-layout.tsx
@@ -2,6 +2,7 @@ import AppLayoutTemplate from '@/layouts/app/app-sidebar-layout';
 import {type BreadcrumbItem} from '@/types';
 import {memo, type ReactNode} from 'react';
 import {NotificationProvider} from '@/contexts/NotificationContext';
+import {AiAssistantProvider} from '@/contexts/AiAssistantContext';
 
 interface AppLayoutProps {
     children: ReactNode;
@@ -12,9 +13,11 @@ interface AppLayoutProps {
 const AppLayout = memo(({children, className, breadcrumbs, ...props}: AppLayoutProps) => {
     return (
         <NotificationProvider>
-            <AppLayoutTemplate breadcrumbs={breadcrumbs} className={className} {...props}>
-                {children}
-            </AppLayoutTemplate>
+            <AiAssistantProvider>
+                <AppLayoutTemplate breadcrumbs={breadcrumbs} className={className} {...props}>
+                    {children}
+                </AppLayoutTemplate>
+            </AiAssistantProvider>
         </NotificationProvider>
     )
 });

--- a/src/assets/js/layouts/app/app-sidebar-layout.tsx
+++ b/src/assets/js/layouts/app/app-sidebar-layout.tsx
@@ -3,21 +3,41 @@ import AppShell from '@/components/app-shell';
 import {AppSidebar} from '@/components/app-sidebar';
 import {AppSidebarHeader} from '@/components/app-sidebar-header';
 import {type BreadcrumbItem} from '@/types';
-import {memo, type PropsWithChildren} from 'react';
+import {memo, type CSSProperties, type PropsWithChildren, useMemo} from 'react';
 import {Head, usePage} from "@inertiajs/react";
+import {AiAssistantPanel, AI_ASSISTANT_PANEL_WIDTH} from '@/components/ai-assistant/AiAssistantPanel';
+import {useAiAssistant} from '@/contexts/AiAssistantContext';
+import clsx from 'clsx';
 
 const AppSidebarLayout = memo(({children, breadcrumbs = [], className}: PropsWithChildren<{
     breadcrumbs?: BreadcrumbItem[],
     className?: string
 }>) => {
     const page = usePage();
+    const {isOpen} = useAiAssistant();
+    const insetStyle = useMemo<CSSProperties | undefined>(() => {
+        if (!isOpen) {
+            return undefined;
+        }
+        return {marginRight: AI_ASSISTANT_PANEL_WIDTH};
+    }, [isOpen]);
+
     return (
         <AppShell variant="sidebar">
             <Head title={page.props.title as string}/>
             <AppSidebar/>
-            <SidebarInset className={className}>
-                <AppSidebarHeader breadcrumbs={breadcrumbs}/>
-                {children}
+            <SidebarInset className="relative flex h-full">
+                <div
+                    className={clsx(
+                        'flex min-h-0 flex-1 flex-col transition-[margin-right] duration-300 ease-in-out',
+                        className
+                    )}
+                    style={insetStyle}
+                >
+                    <AppSidebarHeader breadcrumbs={breadcrumbs}/>
+                    {children}
+                </div>
+                <AiAssistantPanel/>
             </SidebarInset>
         </AppShell>
     );

--- a/src/assets/js/types/index.d.ts
+++ b/src/assets/js/types/index.d.ts
@@ -42,6 +42,10 @@ export interface SharedData {
     flash: Record<FlashMessages, string>;
     auth: Auth;
     notifications: boolean;
+    aiAssistant?: {
+        enabled: boolean;
+        defaultModel: string | null;
+    };
     [key: string]: unknown;
 }
 

--- a/src/controllers/ai/AiAssistantController.ts
+++ b/src/controllers/ai/AiAssistantController.ts
@@ -1,0 +1,116 @@
+import {Adminizer} from '../../lib/Adminizer';
+import {AiAssistantMessage} from '../../interfaces/types';
+
+export class AiAssistantController {
+    static async getModels(req: ReqType, res: ResType) {
+        if (!req.adminizer.config.aiAssistant?.enabled) {
+            return res.json([]);
+        }
+
+        const handler = req.adminizer.aiAssistantHandler;
+        if (!handler) {
+            Adminizer.log.warn('AI assistant handler is not initialized');
+            return res.json([]);
+        }
+
+        const models = handler
+            .getModels()
+            .filter((model) =>
+                req.adminizer.accessRightsHelper.hasPermission(`ai-assistant-${model.id}`, req.user),
+            );
+
+        return res.json(models);
+    }
+
+    static async getHistory(req: ReqType, res: ResType) {
+        if (!req.adminizer.config.aiAssistant?.enabled) {
+            return res.json({history: []});
+        }
+
+        const {modelId} = req.params;
+        if (!modelId) {
+            return res.status(400).json({error: 'Model id is required'});
+        }
+
+        if (!req.adminizer.accessRightsHelper.hasPermission(`ai-assistant-${modelId}`, req.user)) {
+            return res.status(403).json({error: 'Forbidden'});
+        }
+
+        const handler = req.adminizer.aiAssistantHandler;
+        if (!handler) {
+            return res.status(500).json({error: 'AI assistant is not available'});
+        }
+
+        const history = handler.getHistory(req.user.id, modelId).map(AiAssistantController.serializeMessage);
+        return res.json({history});
+    }
+
+    static async sendMessage(req: ReqType, res: ResType) {
+        if (!req.adminizer.config.aiAssistant?.enabled) {
+            return res.status(503).json({error: 'AI assistant is disabled'});
+        }
+
+        const {modelId, message} = req.body as {modelId?: string; message?: string};
+
+        if (!modelId || typeof modelId !== 'string') {
+            return res.status(400).json({error: 'Model id is required'});
+        }
+
+        if (!message || typeof message !== 'string' || message.trim().length === 0) {
+            return res.status(400).json({error: 'Message is required'});
+        }
+
+        if (!req.adminizer.accessRightsHelper.hasPermission(`ai-assistant-${modelId}`, req.user)) {
+            return res.status(403).json({error: 'Forbidden'});
+        }
+
+        const handler = req.adminizer.aiAssistantHandler;
+        if (!handler) {
+            return res.status(500).json({error: 'AI assistant is not available'});
+        }
+
+        try {
+            const response = await handler.sendMessage(req.user, modelId, message.trim());
+            return res.json({
+                modelId,
+                history: response.history.map(AiAssistantController.serializeMessage),
+            });
+        } catch (error) {
+            Adminizer.log.error('AI assistant error', error);
+            return res.status(500).json({error: 'Failed to process request'});
+        }
+    }
+
+    static async resetHistory(req: ReqType, res: ResType) {
+        if (!req.adminizer.config.aiAssistant?.enabled) {
+            return res.status(503).json({error: 'AI assistant is disabled'});
+        }
+
+        const {modelId} = req.params;
+        if (!modelId) {
+            return res.status(400).json({error: 'Model id is required'});
+        }
+
+        if (!req.adminizer.accessRightsHelper.hasPermission(`ai-assistant-${modelId}`, req.user)) {
+            return res.status(403).json({error: 'Forbidden'});
+        }
+
+        const handler = req.adminizer.aiAssistantHandler;
+        if (!handler) {
+            return res.status(500).json({error: 'AI assistant is not available'});
+        }
+
+        handler.resetHistory(req.user.id, modelId);
+        return res.json({history: []});
+    }
+
+    private static serializeMessage(message: AiAssistantMessage) {
+        return {
+            id: message.id,
+            role: message.role,
+            content: message.content,
+            timestamp: message.timestamp instanceof Date ? message.timestamp.toISOString() : message.timestamp,
+            modelId: message.modelId,
+        };
+    }
+}

--- a/src/interfaces/adminpanelConfig.ts
+++ b/src/interfaces/adminpanelConfig.ts
@@ -254,6 +254,11 @@ export interface AdminpanelConfig {
     notifications?: {
         enabled: boolean
     }
+    aiAssistant?: {
+        enabled: boolean
+        defaultModel?: string
+        models?: string[]
+    }
 }
 
 export interface ModelConfig {

--- a/src/interfaces/types.ts
+++ b/src/interfaces/types.ts
@@ -71,6 +71,22 @@ export interface INotificationEvent {
     userId?: number;
 }
 
+export type AiAssistantRole = 'user' | 'assistant';
+
+export interface AiAssistantMessage {
+    id: string;
+    role: AiAssistantRole;
+    content: string;
+    timestamp: Date;
+    modelId: string;
+}
+
+export interface AiAssistantModelInfo {
+    id: string;
+    name: string;
+    description?: string;
+}
+
 export type Migration = {
   name: string;
   timestamp: number,

--- a/src/lib/Adminizer.ts
+++ b/src/lib/Adminizer.ts
@@ -34,9 +34,10 @@ import {ControlsHandler} from "./controls/ControlsHandler";
 import {CatalogHandler} from "./catalog/CatalogHandler";
 import {v4 as uuid} from "uuid";
 import { NotificationHandler } from './notifications/NotificationHandler';
-import { GeneralNotificationService } from './notifications/GeneralNotificationService';
 import { SystemNotificationService } from './notifications/SystemNotificationService';
+import { AiAssistantHandler } from './ai-assistant/AiAssistantHandler';
 import {bindNotifications} from "../system/bindNotifications";
+import {bindAiAssistant} from "../system/bindAiAssistant";
 import {INotification} from "../interfaces/types";
 
 export class Adminizer {
@@ -57,6 +58,7 @@ export class Adminizer {
     configHelper: ConfigHelper
     menuHelper: MenuHelper
     notificationHandler!: NotificationHandler;
+    aiAssistantHandler!: AiAssistantHandler;
     modelHandler!: ModelHandler
     widgetHandler: WidgetHandler
     vite: ViteDevServer
@@ -282,6 +284,8 @@ export class Adminizer {
 
         // Bind notifications
         if (this.config.notifications.enabled) await bindNotifications(this);
+
+        if (this.config.aiAssistant?.enabled) await bindAiAssistant(this);
 
         await Router.bind(this); // must be after binding policies and req/res functions
 

--- a/src/lib/ai-assistant/AbstractAiModelService.ts
+++ b/src/lib/ai-assistant/AbstractAiModelService.ts
@@ -1,0 +1,45 @@
+import {Adminizer} from '../Adminizer';
+import {AiAssistantMessage, AiAssistantModelInfo} from '../../interfaces/types';
+import {UserAP} from '../../models/UserAP';
+
+/**
+ * Base class for AI assistant models. It is responsible for registering
+ * access rights for the model and providing metadata for the front-end.
+ */
+export abstract class AbstractAiModelService {
+    protected readonly adminizer: Adminizer;
+    public readonly id: string;
+    public readonly name: string;
+    public readonly description?: string;
+
+    protected constructor(adminizer: Adminizer, metadata: AiAssistantModelInfo) {
+        this.adminizer = adminizer;
+        this.id = metadata.id;
+        this.name = metadata.name;
+        this.description = metadata.description;
+        this.registerAccessRight();
+    }
+
+    protected registerAccessRight(): void {
+        this.adminizer.accessRightsHelper.registerToken({
+            id: `ai-assistant-${this.id}`,
+            name: this.name,
+            description: `Access to AI assistant model ${this.name}`,
+            department: 'AI Assistant',
+        });
+    }
+
+    public getMetadata(): AiAssistantModelInfo {
+        return {
+            id: this.id,
+            name: this.name,
+            description: this.description,
+        };
+    }
+
+    public abstract generateReply(
+        prompt: string,
+        history: AiAssistantMessage[],
+        user: UserAP,
+    ): Promise<string>;
+}

--- a/src/lib/ai-assistant/AiAssistantHandler.ts
+++ b/src/lib/ai-assistant/AiAssistantHandler.ts
@@ -1,0 +1,79 @@
+import {v4 as uuid} from 'uuid';
+import {Adminizer} from '../Adminizer';
+import {AbstractAiModelService} from './AbstractAiModelService';
+import {AiAssistantMessage, AiAssistantModelInfo} from '../../interfaces/types';
+import {UserAP} from '../../models/UserAP';
+
+export class AiAssistantHandler {
+    private readonly models = new Map<string, AbstractAiModelService>();
+    private readonly history = new Map<string, AiAssistantMessage[]>();
+
+    constructor(private readonly adminizer: Adminizer) {}
+
+    registerModel(service: AbstractAiModelService): void {
+        if (this.models.has(service.id)) {
+            Adminizer.log.warn(
+                `AI assistant model with id "${service.id}" is already registered. Overwriting.`,
+            );
+        }
+        this.models.set(service.id, service);
+    }
+
+    getModel(id: string): AbstractAiModelService | undefined {
+        return this.models.get(id);
+    }
+
+    getModels(): AiAssistantModelInfo[] {
+        return Array.from(this.models.values()).map((service) => service.getMetadata());
+    }
+
+    getHistory(userId: number, modelId: string): AiAssistantMessage[] {
+        return this.history.get(this.getSessionKey(userId, modelId)) ?? [];
+    }
+
+    resetHistory(userId: number, modelId: string): void {
+        this.history.delete(this.getSessionKey(userId, modelId));
+    }
+
+    async sendMessage(
+        user: UserAP,
+        modelId: string,
+        prompt: string,
+    ): Promise<{history: AiAssistantMessage[]}> {
+        const service = this.getModel(modelId);
+        if (!service) {
+            throw new Error(`AI assistant model not found: ${modelId}`);
+        }
+
+        const sessionKey = this.getSessionKey(user.id, modelId);
+        const currentHistory = [...this.getHistory(user.id, modelId)];
+
+        const userMessage: AiAssistantMessage = {
+            id: uuid(),
+            role: 'user',
+            content: prompt,
+            timestamp: new Date(),
+            modelId,
+        };
+        currentHistory.push(userMessage);
+
+        const reply = await service.generateReply(prompt, currentHistory, user);
+
+        const assistantMessage: AiAssistantMessage = {
+            id: uuid(),
+            role: 'assistant',
+            content: reply,
+            timestamp: new Date(),
+            modelId,
+        };
+
+        currentHistory.push(assistantMessage);
+        this.history.set(sessionKey, currentHistory);
+
+        return {history: currentHistory};
+    }
+
+    private getSessionKey(userId: number, modelId: string): string {
+        return `${userId}:${modelId}`;
+    }
+}

--- a/src/lib/ai-assistant/DummyAiModelService.ts
+++ b/src/lib/ai-assistant/DummyAiModelService.ts
@@ -1,0 +1,24 @@
+import {AbstractAiModelService} from './AbstractAiModelService';
+import {AiAssistantMessage} from '../../interfaces/types';
+import {UserAP} from '../../models/UserAP';
+import {Adminizer} from '../Adminizer';
+
+const DUMMY_RESPONSE = 'Ai-assystant dummy in deveploment';
+
+export class DummyAiModelService extends AbstractAiModelService {
+    public constructor(adminizer: Adminizer) {
+        super(adminizer, {
+            id: 'dummy',
+            name: 'Dummy assistant',
+            description: 'Development placeholder model that returns a static response.',
+        });
+    }
+
+    public async generateReply(
+        _prompt: string,
+        _history: AiAssistantMessage[],
+        _user: UserAP,
+    ): Promise<string> {
+        return DUMMY_RESPONSE;
+    }
+}

--- a/src/system/Router.ts
+++ b/src/system/Router.ts
@@ -20,6 +20,7 @@ import {thumbController} from "../controllers/media-manager/ThumbController";
 import {Adminizer} from "../lib/Adminizer";
 import timezones from "../controllers/timezones";
 import {NotificationController} from "../controllers/notifications/NotificationController";
+import {AiAssistantController} from "../controllers/ai/AiAssistantController";
 
 export default class Router {
 
@@ -158,6 +159,28 @@ export default class Router {
                 adminizer.policyManager.bindPolicies(policies, NotificationController.search)
             );
         }
+        if (adminizer.config.aiAssistant?.enabled) {
+            adminizer.app.get(
+                `${adminizer.config.routePrefix}/api/ai-assistant/models`,
+                adminizer.policyManager.bindPolicies(policies, AiAssistantController.getModels)
+            );
+
+            adminizer.app.get(
+                `${adminizer.config.routePrefix}/api/ai-assistant/history/:modelId`,
+                adminizer.policyManager.bindPolicies(policies, AiAssistantController.getHistory)
+            );
+
+            adminizer.app.post(
+                `${adminizer.config.routePrefix}/api/ai-assistant/query`,
+                adminizer.policyManager.bindPolicies(policies, AiAssistantController.sendMessage)
+            );
+
+            adminizer.app.delete(
+                `${adminizer.config.routePrefix}/api/ai-assistant/history/:modelId`,
+                adminizer.policyManager.bindPolicies(policies, AiAssistantController.resetHistory)
+            );
+        }
+
         /**
          * List of records
          */

--- a/src/system/bindAiAssistant.ts
+++ b/src/system/bindAiAssistant.ts
@@ -1,0 +1,32 @@
+import {Adminizer} from '../lib/Adminizer';
+import {AiAssistantHandler} from '../lib/ai-assistant/AiAssistantHandler';
+import {DummyAiModelService} from '../lib/ai-assistant/DummyAiModelService';
+import {AbstractAiModelService} from '../lib/ai-assistant/AbstractAiModelService';
+
+const modelFactories: Record<string, (adminizer: Adminizer) => AbstractAiModelService> = {
+    dummy: (adminizer) => new DummyAiModelService(adminizer),
+};
+
+export async function bindAiAssistant(adminizer: Adminizer): Promise<void> {
+    adminizer.aiAssistantHandler = new AiAssistantHandler(adminizer);
+
+    const configModels = adminizer.config.aiAssistant?.models;
+    const requestedModels = Array.isArray(configModels) && configModels.length > 0
+        ? configModels
+        : ['dummy'];
+
+    requestedModels.forEach((modelId) => {
+        const factory = modelFactories[modelId];
+        if (!factory) {
+            Adminizer.log.warn(`AI assistant model "${modelId}" is not registered. Skipping.`);
+            return;
+        }
+
+        const service = factory(adminizer);
+        adminizer.aiAssistantHandler.registerModel(service);
+    });
+
+    Adminizer.log.info(
+        `AI assistant initialized with models: ${adminizer.aiAssistantHandler.getModels().map((m) => m.id).join(', ')}`,
+    );
+}

--- a/src/system/bindInertia.ts
+++ b/src/system/bindInertia.ts
@@ -155,6 +155,10 @@ export function bindInertia(adminizer: Adminizer) {
             ] : null,
             showVersion: req.adminizer.config.showVersion ?? false,
             notifications: req.adminizer.config.notifications.enabled ?? false,
+            aiAssistant: {
+                enabled: req.adminizer.config.aiAssistant?.enabled ?? false,
+                defaultModel: req.adminizer.config.aiAssistant?.defaultModel ?? null,
+            },
         });
 
         next();

--- a/src/system/defaults.ts
+++ b/src/system/defaults.ts
@@ -154,6 +154,11 @@ let adminpanelConfig: AdminpanelConfig = {
     },
     notifications: {
         enabled: false
+    },
+    aiAssistant: {
+        enabled: false,
+        defaultModel: 'dummy',
+        models: ['dummy']
     }
 }
 


### PR DESCRIPTION
## Summary
- replace the modal-based AI assistant experience with a docked chat panel that slides in from the right of the app frame
- shift the main sidebar layout when the panel is open and reuse the toggle button to control the docked experience
- document the docked assistant UI and record the update in HISTORY

## Testing
- npm install *(fails: @toast-ui/react-editor requires React 17 while the project uses React 19)*
- npm run build *(fails: shelljs missing because installation cannot complete)*
- npm test *(fails: vitest binary missing before dependencies install)*

------
https://chatgpt.com/codex/tasks/task_e_68d638d91724832aa31698319ff16648